### PR TITLE
docs(ops): add quick prod-ready validation script and runbook steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ npm run dev
 
 - 에러 표준 검증: `scripts/test-error-code.ps1`
 - 인증 상태 검증(`/auth/me`): `scripts/test-auth-me.ps1`
+- 배포 전 빠른 통합 검증: `scripts/test-prod-ready.ps1`
 
 ## 문서 바로가기
 

--- a/docs/operations/deploy-runbook.md
+++ b/docs/operations/deploy-runbook.md
@@ -52,6 +52,17 @@
 - `error.code` 응답 확인
   - `scripts/test-error-code.ps1`
   - `scripts/test-auth-me.ps1`
+  - `scripts/test-prod-ready.ps1` (배포 전 빠른 통합 점검)
+
+4. 빠른 통합 점검(권장)
+- 로컬/운영 공통으로 아래 스크립트를 먼저 실행한다.
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\test-prod-ready.ps1 -ApiBaseUrl "https://<api-domain>"
+```
+- 액세스 토큰까지 함께 검증하려면 아래처럼 실행한다.
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\test-prod-ready.ps1 -ApiBaseUrl "https://<api-domain>" -AccessToken "<ACCESS_TOKEN>"
+```
 
 ## 4) Redirect URI 최종 검증 (필수)
 

--- a/scripts/test-prod-ready.ps1
+++ b/scripts/test-prod-ready.ps1
@@ -1,0 +1,47 @@
+﻿param(
+  [string]$ApiBaseUrl = "http://localhost:3010",
+  [string]$AccessToken = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "=== MVP2-A 배포 전 빠른 검증 ===" -ForegroundColor Cyan
+Write-Host "API Base URL: $ApiBaseUrl"
+
+# 1) 서버 헬스체크 검증
+Write-Host "`n[1/3] /api/health 확인"
+$health = Invoke-RestMethod -Method Get -Uri "$ApiBaseUrl/api/health"
+if (-not $health.ok) {
+  throw "health check failed"
+}
+Write-Host "[PASS] health.ok = true" -ForegroundColor Green
+
+# 2) 인증 없이 보호 API 접근 시 표준 에러 형식 검증
+Write-Host "`n[2/3] 인증 없는 /api/chatrooms 에러 형식 확인"
+try {
+  Invoke-RestMethod -Method Get -Uri "$ApiBaseUrl/api/chatrooms" | Out-Null
+  throw "expected unauthorized error"
+} catch {
+  $raw = $_.ErrorDetails.Message
+  if (-not $raw) { throw }
+  $errObj = $raw | ConvertFrom-Json
+  if (-not $errObj.error.code) {
+    throw "error.code is missing"
+  }
+  Write-Host "[PASS] error.code = $($errObj.error.code)" -ForegroundColor Green
+}
+
+# 3) 토큰을 넣은 경우 /auth/me 확인 (옵션)
+Write-Host "`n[3/3] /auth/me 확인 (토큰 옵션)"
+if ([string]::IsNullOrWhiteSpace($AccessToken)) {
+  Write-Host "[SKIP] -AccessToken 미입력으로 건너뜀"
+} else {
+  $headers = @{ Authorization = "Bearer $AccessToken" }
+  $me = Invoke-RestMethod -Method Get -Uri "$ApiBaseUrl/auth/me" -Headers $headers
+  if (-not $me.user.id) {
+    throw "/auth/me user.id missing"
+  }
+  Write-Host "[PASS] user.id = $($me.user.id)" -ForegroundColor Green
+}
+
+Write-Host "`n=== 완료: 빠른 검증 통과 ===" -ForegroundColor Cyan


### PR DESCRIPTION

실운영 검증 전에 바로 실행할 수 있는 빠른 점검 스크립트를 추가하고, 런북/README에 실행 절차를 연결

Changed Files  
- [scripts/test-prod-ready.ps1](c:/Users/yoooo/flownium-chat-2.0/scripts/test-prod-ready.ps1)  
- [docs/operations/deploy-runbook.md](c:/Users/yoooo/flownium-chat-2.0/docs/operations/deploy-runbook.md)  
- [README.md](c:/Users/yoooo/flownium-chat-2.0/README.md)

What’s Included  
- `test-prod-ready.ps1` 추가
  - `/api/health` 확인
  - 무인증 보호 API 호출 시 `error.code` 존재 확인
  - 옵션으로 `/auth/me` 토큰 검증
- 배포 런북에 빠른 통합 점검 명령 추가
- README 검증 스크립트 목록 최신화

Impact  
- 실배포 전 검증 속도 향상  
- 운영 검증 절차 표준화 강화

Validation  
- 스크립트/문서 반영 확인  
- 커밋/푸시 완료

Branch / Commit  
- Branch: `feat/mvp2a-live-deploy-validation`  
- Commit: `64cd3ea`  
- Push: `origin/feat/mvp2a-live-deploy-validation`

PR  
- 생성 링크: `https://github.com/yoooon0104/flownium-chat-2.0/pull/new/feat/mvp2a-live-deploy-validation`