### PR TITLE
docs(ops): add local dry-run deploy validation record

### DIFF
--- a/docs/operations/deploy-runbook.md
+++ b/docs/operations/deploy-runbook.md
@@ -133,3 +133,19 @@ powershell -ExecutionPolicy Bypass -File .\scripts\test-prod-ready.ps1 -ApiBaseU
 2. 반영 커밋/PR
 3. 검증 결과
 4. 이슈/롤백 여부
+
+## 10) 최근 실행 기록
+
+### Deploy Record (Local Dry Run)
+- 일시: 2026-03-05
+- 환경(Prod/Local): Local
+- 프론트 도메인: `http://localhost:5173`
+- 백엔드 도메인: `http://localhost:3010`
+- 반영 브랜치/커밋: `feat/mvp2a-live-deploy-validation` / `64cd3ea`
+- 체크리스트 결과:
+  - `scripts/test-prod-ready.ps1 -ApiBaseUrl "http://localhost:3010"` PASS
+  - `/api/health` PASS
+  - 무인증 `/api/chatrooms` -> `error.code=UNAUTHORIZED` PASS
+  - `/auth/me`는 토큰 미입력으로 SKIP
+- Redirect URI 검증 결과: 운영값 미검증(로컬 기준만 확인)
+- 이슈/대응: 없음


### PR DESCRIPTION
Summary  
로컬 기준 실검증 실행 결과를 런북에 기록으로 남겼습니다. 운영 검증 시 동일 포맷으로 이어서 작성하면 됩니다.

Changed Files  
- [docs/operations/deploy-runbook.md](c:/Users/yoooo/flownium-chat-2.0/docs/operations/deploy-runbook.md)

What’s Included  
- `## 10) 최근 실행 기록` 섹션 추가
- `Deploy Record (Local Dry Run)` 항목 추가
- `test-prod-ready.ps1` 실행 결과 PASS/SKIP 상태 문서화

Branch / Commit  
- Branch: `feat/mvp2a-live-deploy-validation`  
- Commit: `109ce42`  
- Push: 완료

PR  
- 기존 PR 링크 그대로 사용: `https://github.com/yoooon0104/flownium-chat-2.0/pull/new/feat/mvp2a-live-deploy-validation`