### PR TITLE
fix(auth): guard kakao callback code from duplicate processing

### DIFF
--- a/src/features/auth/hooks/useKakaoAuth.js
+++ b/src/features/auth/hooks/useKakaoAuth.js
@@ -5,11 +5,18 @@ import { createAuthApi } from '../../../services/api/authApi'
 
 const KAKAO_CLIENT_ID = import.meta.env.VITE_KAKAO_REST_API_KEY || import.meta.env.VITE_KAKAO_CLIENT_ID || ''
 const KAKAO_REDIRECT_URI = import.meta.env.VITE_KAKAO_REDIRECT_URI || `${window.location.origin}`
+const KAKAO_AUTH_CODE_STORAGE_KEY = 'flownium:kakao-auth-code'
+const KAKAO_AUTH_IN_PROGRESS_STORAGE_KEY = 'flownium:kakao-auth-in-progress'
 
 const resolveErrorMessage = (body, fallback) => {
   if (body?.error?.message) return String(body.error.message)
   if (typeof body?.error === 'string') return body.error
   return fallback
+}
+
+const clearKakaoCallbackQuery = () => {
+  const nextUrl = `${window.location.pathname}${window.location.hash || ''}`
+  window.history.replaceState({}, document.title, nextUrl)
 }
 
 // 인증 상태와 온보딩 분기를 훅으로 묶어 AppShell이 화면 조합에만 집중하도록 만든다.
@@ -129,11 +136,23 @@ export const useKakaoAuth = (apiBaseUrl) => {
     const run = async () => {
       const params = new URLSearchParams(window.location.search)
       const code = String(params.get('code') || '').trim()
+      const handledCode = window.sessionStorage.getItem(KAKAO_AUTH_CODE_STORAGE_KEY)
+      const inProgressCode = window.sessionStorage.getItem(KAKAO_AUTH_IN_PROGRESS_STORAGE_KEY)
 
       try {
         setError('')
 
         if (code) {
+          // 같은 인가 코드를 새로고침/중복 렌더로 다시 보내지 않도록 먼저 URL query를 제거한다.
+          clearKakaoCallbackQuery()
+
+          if (code === handledCode || code === inProgressCode) {
+            throw new Error('이미 처리한 로그인 요청입니다. 처음 화면에서 다시 로그인해주세요.')
+          }
+
+          // 카카오 인가 코드는 1회용이므로 처리 중 상태를 먼저 기록해 중복 교환을 차단한다.
+          window.sessionStorage.setItem(KAKAO_AUTH_IN_PROGRESS_STORAGE_KEY, code)
+
           const { ok, body } = await authApi.getKakaoCallback(code)
           if (!ok || !body) {
             throw new Error(resolveErrorMessage(body, '카카오 로그인 처리에 실패했습니다.'))
@@ -158,8 +177,8 @@ export const useKakaoAuth = (apiBaseUrl) => {
             throw new Error('지원하지 않는 인증 응답입니다.')
           }
 
-          // 콜백 처리 완료 후 주소창 query를 제거한다.
-          window.history.replaceState({}, document.title, window.location.pathname)
+          window.sessionStorage.setItem(KAKAO_AUTH_CODE_STORAGE_KEY, code)
+          window.sessionStorage.removeItem(KAKAO_AUTH_IN_PROGRESS_STORAGE_KEY)
           return
         }
 
@@ -191,6 +210,7 @@ export const useKakaoAuth = (apiBaseUrl) => {
 
         clearSession(resolveErrorMessage(me.body, '세션 정보를 불러오지 못했습니다. 다시 로그인해주세요.'))
       } catch (nextError) {
+        window.sessionStorage.removeItem(KAKAO_AUTH_IN_PROGRESS_STORAGE_KEY)
         console.error('[auth:init] failed', nextError)
         clearSession(nextError.message || '카카오 로그인 처리에 실패했습니다.')
       } finally {
@@ -218,4 +238,3 @@ export const useKakaoAuth = (apiBaseUrl) => {
     clearSession,
   }
 }
-


### PR DESCRIPTION
Title  
`fix(auth): guard kakao callback code from duplicate processing`

Summary  
카카오 OAuth 인가 코드가 새로고침이나 중복 초기화로 두 번 처리되면서 `KOE320`가 발생하던 흐름을 프론트에서 제어

Changed Files  
- [useKakaoAuth.js](c:/Users/yoooo/flownium-chat-2.0/src/features/auth/hooks/useKakaoAuth.js)

What’s Included  
- 콜백 URL의 `code`를 읽은 직후 주소창 query를 바로 제거
- `sessionStorage`에 처리 중인 code / 이미 처리한 code를 기록
- 같은 인가 코드를 다시 서버로 보내지 않도록 중복 차단
- 관련 에러 메시지를 로그인 재시도 문맥에 맞게 정리

Impact  
- 카카오 로그인 후 새로고침/중복 렌더 시 `authorization code not found` 재발 가능성 감소
- 운영 로그인 흐름 안정성 개선

Validation  
- `node --check src/features/auth/hooks/useKakaoAuth.js` 통과
- 커밋/푸시 완료

Branch / Commit  
- Branch: `feat/mvp2a-live-deploy-validation`
- Commit: `baf41fb`
- Push: `origin/feat/mvp2a-live-deploy-validation`

PR  
- `https://github.com/yoooon0104/flownium-chat-2.0/pull/new/feat/mvp2a-live-deploy-validation`