### PR TITLE
docs(code): add detailed unread flow comments

### DIFF
--- a/server/index.cjs
+++ b/server/index.cjs
@@ -43,6 +43,7 @@ const io = new Server(server, {
 });
 
 // roomId -> (userId -> Set(socketId)) 구조로 룸별 온라인 상태를 관리한다.
+// unread count와는 별도 개념이다. presence는 지금 접속 중인지, read state는 마지막으로 어디까지 읽었는지를 의미한다.
 const roomPresence = new Map();
 
 const assertDbConnected = (res) => {
@@ -386,12 +387,15 @@ io.on('connection', (socket) => {
       room.lastMessageAt = message.timestamp;
       await room.save();
 
+      // 새 메시지를 보낸 직후 unreadCount를 계산해 두면 같은 payload를 현재 방/다른 방 UI에서 모두 재사용할 수 있다.
+      // 보낸 사람 자신은 unread 대상이 아니므로 읽음 상태 조회 대상에서도 제외한다.
       const memberIds = Array.isArray(room.memberIds) ? room.memberIds.map((value) => String(value)) : [];
       const targetReadStates = await ChatReadState.find({
         roomId,
         userId: { $in: memberIds.filter((memberId) => memberId !== socket.user.userId) },
       }).lean();
       const readStateByUserId = new Map(targetReadStates.map((state) => [String(state.userId), state]));
+      // 규칙: lastReadAt이 없거나 메시지 시각보다 이전이면 아직 읽지 않은 것으로 본다.
       const unreadCount = memberIds.filter((memberId) => {
         if (memberId === socket.user.userId) return false;
         const readState = readStateByUserId.get(String(memberId));
@@ -452,3 +456,4 @@ start().catch((error) => {
   console.error('Failed to start server:', error.message);
   process.exit(1);
 });
+

--- a/server/routes/chatroom.routes.cjs
+++ b/server/routes/chatroom.routes.cjs
@@ -16,6 +16,8 @@ const createChatroomRouter = ({
 }) => {
   const router = express.Router();
 
+  // 방 목록 응답 형태를 한곳에서 고정해 두면 create/get 응답이 서로 어긋나지 않는다.
+  // unreadCount는 조회 시점의 현재 사용자 기준 값이므로 기본값을 0으로 둔다.
   const toRoomResponse = (roomDoc, unreadCount = 0) => ({
     id: String(roomDoc._id),
     name: roomDoc.name,
@@ -26,6 +28,7 @@ const createChatroomRouter = ({
     unreadCount: Number(unreadCount) || 0,
   });
 
+  // 친구 요청이나 방 초대는 DB 저장만으로 끝내지 않고, 소켓 이벤트까지 같이 보내 즉시 화면에 반영한다.
   const createNotification = async (userId, type, payload) => {
     if (!Notification) return null;
 
@@ -47,6 +50,7 @@ const createChatroomRouter = ({
     return notification;
   };
 
+  // 프론트에서 비친구를 숨기더라도 서버가 다시 검증해야 직접 호출이나 오래된 UI 상태를 막을 수 있다.
   const hasAcceptedFriendship = async (me, targetUserId) => {
     if (!Friendship) return false;
 
@@ -58,6 +62,8 @@ const createChatroomRouter = ({
     return Boolean(friendship);
   };
 
+  // 1:1 방 재사용 규칙: 같은 두 사람만 들어 있는 방이면 direct 성격으로 보고 재사용한다.
+  // 별도 type 필드를 강제하지 않았기 때문에 memberIds 길이 2를 기준으로 판별한다.
   const findExistingDirectRoom = async (memberA, memberB) => {
     const rooms = await ChatRoom.find({
       memberIds: { $all: [memberA, memberB] },
@@ -68,6 +74,10 @@ const createChatroomRouter = ({
     return rooms.find((room) => Array.isArray(room.memberIds) && room.memberIds.length === 2) || null;
   };
 
+  // 방 목록 unread 계산 규칙:
+  // - 내가 보낸 메시지는 unread에서 제외
+  // - lastReadAt이 있으면 그 이후 메시지만 unread로 계산
+  // - lastReadAt이 없으면 상대가 보낸 메시지를 전부 unread로 본다.
   const getUnreadCountForRoom = async (roomId, userId, lastReadAt) => {
     const query = {
       chatRoomId: roomId,
@@ -81,6 +91,10 @@ const createChatroomRouter = ({
     return Message.countDocuments(query);
   };
 
+  // 메시지별 unreadCount 계산 규칙:
+  // - 보낸 사람 자신은 unread 대상에서 제외
+  // - 각 멤버의 lastReadAt과 메시지 timestamp를 비교해 아직 읽지 않은 인원 수를 만든다
+  // - 이 값은 채팅창에서 '(숫자) 메시지' 형태로 그대로 쓰인다.
   const buildMessageResponses = (messages, memberIds, readStateByUserId) =>
     messages.map((message) => {
       const timestamp = message.timestamp ? new Date(message.timestamp) : null;
@@ -103,6 +117,10 @@ const createChatroomRouter = ({
       };
     });
 
+  // 채팅방 생성 흐름:
+  // - memberUserIds가 없으면 기존 name 기반 그룹방 생성 호환 로직으로 처리
+  // - 1명 선택이면 기존 2인 방 재사용 또는 새 생성
+  // - 2명 이상 선택이면 그룹방 생성 후 초대 알림을 보낸다.
   router.post('/chatrooms', requireAuth, async (req, res) => {
     const currentUserId = req.user.userId;
     const name = String(req.body?.name || '').trim();
@@ -217,6 +235,8 @@ const createChatroomRouter = ({
     }
   });
 
+  // 방 목록 조회는 unread count까지 같이 계산한다.
+  // 프론트는 rooms 배열과 totalUnreadCount를 받아 목록 배지와 탭 총합 배지를 한 번에 그린다.
   router.get('/chatrooms', requireAuth, async (req, res) => {
     if (!assertDbConnected(res)) {
       return;
@@ -250,6 +270,8 @@ const createChatroomRouter = ({
     }
   });
 
+  // 메시지 히스토리 조회 시점에도 unreadCount를 다시 계산한다.
+  // 그래야 새로고침 후에도 메시지 옆 unread 숫자를 동일하게 복원할 수 있다.
   router.get('/chatrooms/:id/messages', requireAuth, async (req, res) => {
     const roomId = String(req.params.id || '').trim();
     const limit = Math.min(Math.max(Number(req.query.limit) || 50, 1), 100);
@@ -341,3 +363,4 @@ const createChatroomRouter = ({
 };
 
 module.exports = createChatroomRouter;
+

--- a/src/app/AppShell.jsx
+++ b/src/app/AppShell.jsx
@@ -171,6 +171,7 @@ function AppShell() {
     clearNotifications()
   }, [clearFriends, clearMessages, clearNotifications, clearRooms, clearSession, setErrorMessage])
 
+  // 소켓 재연결 시점에는 서버 메모리 상태가 바뀌었을 수 있으므로, 방/친구/알림 목록을 모두 다시 불러와 화면 기준 상태를 맞춘다.
   const handleSocketConnect = useCallback(() => {
     setErrorMessage('')
     void fetchRooms()
@@ -186,6 +187,11 @@ function AppShell() {
     return refreshed
   }, [handleLogout, refreshAccessToken])
 
+  // 방 입장 직후 흐름:
+  // 1) 현재 방 상태 반영
+  // 2) 과거 메시지 로드
+  // 3) 방을 실제로 열어본 시점으로 읽음 처리
+  // 이 순서를 지켜야 새로 입장한 방의 unread 배지가 바로 정리된다.
   const handleSocketRoomJoined = useCallback((nextRoomId) => {
     setJoinedRoomId(nextRoomId)
     setIsMobileChatView(true)
@@ -198,6 +204,10 @@ function AppShell() {
     })()
   }, [loadMessageHistory, markRoomRead])
 
+  // 실시간 메시지 수신 분기:
+  // - 현재 열려 있는 방 + 내가 아닌 상대 메시지면 곧바로 읽음 처리
+  // - 그 외에는 방 목록만 다시 받아 unread 배지만 갱신
+  // 이렇게 나누면 현재 방에서는 숫자가 즉시 줄고, 다른 방에서는 목록 배지만 늘어난다.
   const handleSocketReceiveMessage = useCallback((message) => {
     appendMessage(message)
 
@@ -526,3 +536,4 @@ function AppShell() {
 }
 
 export default AppShell
+

--- a/src/features/chat/components/ChatPanel.jsx
+++ b/src/features/chat/components/ChatPanel.jsx
@@ -1,6 +1,7 @@
 ﻿import ParticipantsMenu from './ParticipantsMenu'
 
 // 채팅 본문 패널: 헤더/메시지/입력창을 조합하고 모바일 뒤로가기를 처리한다.
+// unread 숫자는 메시지별 unreadCount를 그대로 받아 '(숫자) 메시지' 형태로 렌더링한다.
 function ChatPanel({
   isMobileChatView,
   activeRoom,
@@ -54,6 +55,8 @@ function ChatPanel({
                 <li key={msg.id || `${msg.timestamp}-${idx}`} className={isMine ? 'mine' : 'other'}>
                   <p className="meta">{msg.senderNickname}</p>
                   <div className={`bubble-row ${isMine ? 'mine' : 'other'}`}>
+                    {/* unreadCount는 읽지 않은 사람 수이므로 0보다 클 때만 노출한다.
+                        현재 UX 규칙은 말풍선이 아니라 텍스트 숫자만 메시지 앞에 붙이는 방식이다. */}
                     {Number(msg.unreadCount) > 0 && (
                       <span className="message-unread-count">{msg.unreadCount > 99 ? '99+' : msg.unreadCount}</span>
                     )}
@@ -85,4 +88,5 @@ function ChatPanel({
 }
 
 export default ChatPanel
+
 

--- a/src/features/chat/hooks/useChatRooms.js
+++ b/src/features/chat/hooks/useChatRooms.js
@@ -15,6 +15,7 @@ export const useChatRooms = ({ chatApi }) => {
   const [errorMessage, setErrorMessage] = useState('')
   const [totalUnreadCount, setTotalUnreadCount] = useState(0)
 
+  // 목록 재조회는 방 이름/최근 메시지뿐 아니라 unreadCount와 totalUnreadCount를 같이 갱신하는 역할을 한다.
   const fetchRooms = useCallback(async () => {
     if (!chatApi) return
 
@@ -46,6 +47,8 @@ export const useChatRooms = ({ chatApi }) => {
     return { ok: true, roomId, reused: Boolean(body?.reused) }
   }, [chatApi, fetchRooms])
 
+  // 사용자가 방에 진입했거나 현재 열려 있는 방에서 새 메시지를 확인한 시점에 호출한다.
+  // 서버에 읽음 상태를 기록한 뒤 방 목록을 다시 받아와 배지를 즉시 줄인다.
   const markRoomRead = useCallback(async (roomId) => {
     if (!chatApi || !roomId) return { ok: false }
 
@@ -92,3 +95,4 @@ export const useChatRooms = ({ chatApi }) => {
     clearRooms,
   }
 }
+

--- a/src/services/api/chatApi.js
+++ b/src/services/api/chatApi.js
@@ -29,6 +29,7 @@ export const createChatApi = ({ apiBaseUrl, getAccessToken, onUnauthorizedRetry 
     return response
   }
 
+  // 방 목록 응답에는 각 방 unreadCount와 전체 totalUnreadCount가 함께 들어온다.
   const getRooms = async () => {
     const response = await fetchWithAuth(`${apiBaseUrl}/api/chatrooms`)
     const body = await parseJsonSafe(response)
@@ -47,12 +48,15 @@ export const createChatApi = ({ apiBaseUrl, getAccessToken, onUnauthorizedRetry 
     return { ok: response.ok, status: response.status, body }
   }
 
+  // 메시지 히스토리 응답에는 텍스트뿐 아니라 메시지별 unreadCount도 포함된다.
   const getRoomMessages = async (roomId, limit = 50) => {
     const response = await fetchWithAuth(`${apiBaseUrl}/api/chatrooms/${roomId}/messages?limit=${limit}`)
     const body = await parseJsonSafe(response)
     return { ok: response.ok, status: response.status, body }
   }
 
+  // 사용자가 실제로 방에 들어왔을 때 마지막 읽은 시점을 서버에 반영한다.
+  // 이 호출이 성공하면 이후 방 목록 배지와 메시지 unread 숫자가 다시 계산된다.
   const markRoomRead = async (roomId) => {
     const response = await fetchWithAuth(`${apiBaseUrl}/api/chatrooms/${roomId}/read`, {
       method: 'PATCH',
@@ -121,3 +125,4 @@ export const createChatApi = ({ apiBaseUrl, getAccessToken, onUnauthorizedRetry 
     markNotificationRead,
   }
 }
+


### PR DESCRIPTION
Title  
`docs(code): add detailed unread flow comments`

Summary  
Unread 흐름이 들어간 소스 파일에 상세한 한국어 주석을 추가했습니다. 계산 기준, 읽음 처리 시점, 현재 방/다른 방 분기 이유가 코드만 봐도 바로 따라가게 정리한 커밋

Changed Files  
- [index.cjs](c:/Users/yoooo/flownium-chat-2.0/server/index.cjs)
- [chatroom.routes.cjs](c:/Users/yoooo/flownium-chat-2.0/server/routes/chatroom.routes.cjs)
- [AppShell.jsx](c:/Users/yoooo/flownium-chat-2.0/src/app/AppShell.jsx)
- [ChatPanel.jsx](c:/Users/yoooo/flownium-chat-2.0/src/features/chat/components/ChatPanel.jsx)
- [useChatRooms.js](c:/Users/yoooo/flownium-chat-2.0/src/features/chat/hooks/useChatRooms.js)
- [chatApi.js](c:/Users/yoooo/flownium-chat-2.0/src/services/api/chatApi.js)

What’s Included  
- 방 목록 unread 계산 규칙 주석
- 메시지별 unreadCount 계산 규칙 주석
- 방 입장 직후 `히스토리 로드 -> 읽음 처리` 순서 설명
- 현재 방/다른 방 메시지 수신 분기 설명
- API 훅이 읽음 처리 후 목록을 다시 받아오는 이유 설명
- 채팅창 `(숫자) 메시지` 렌더링 의도 설명

Impact  
- unread 관련 로직 추적이 쉬워짐
- 다음에 읽음/알림/메시지 로직 손볼 때 진입 비용 감소

Validation  
- `node --check server/index.cjs` 통과
- `node --check server/routes/chatroom.routes.cjs` 통과
- `npm run build` 통과

Branch / Commit  
- Branch: `feat/unread-count-foundation`
- Commit: `321927d`

PR  
- Compare 링크: `https://github.com/yoooon0104/flownium-chat-2.0/compare/main...feat/unread-count-foundation?expand=1`