### PR TITLE
fix(socket): sync realtime messages and notifications

### DIFF
--- a/src/app/AppShell.jsx
+++ b/src/app/AppShell.jsx
@@ -209,13 +209,16 @@ function AppShell() {
   // - 그 외에는 방 목록만 다시 받아 unread 배지만 갱신
   // 이렇게 나누면 현재 방에서는 숫자가 즉시 줄고, 다른 방에서는 목록 배지만 늘어난다.
   const handleSocketReceiveMessage = useCallback((message) => {
-    appendMessage(message)
-
     void (async () => {
-      if (message?.senderId && message.senderId !== currentUser?.id && message?.chatRoomId === joinedRoomId) {
-        await markRoomRead(message.chatRoomId)
+      if (message?.chatRoomId === joinedRoomId) {
+        appendMessage(message)
+
+        if (message?.senderId && message.senderId !== currentUser?.id) {
+          await markRoomRead(message.chatRoomId)
+        }
         return
       }
+
       await fetchRooms()
     })()
   }, [appendMessage, currentUser?.id, fetchRooms, joinedRoomId, markRoomRead])
@@ -223,6 +226,14 @@ function AppShell() {
   const handleSocketParticipants = useCallback((nextParticipants) => {
     setParticipants(nextParticipants)
   }, [])
+
+  const handleSocketNotificationCreated = useCallback(() => {
+    void fetchNotifications()
+  }, [fetchNotifications])
+
+  const handleSocketNotificationRead = useCallback(() => {
+    void fetchNotifications()
+  }, [fetchNotifications])
 
   const handleSocketError = useCallback((message) => {
     setErrorMessage(message)
@@ -243,6 +254,8 @@ function AppShell() {
     onRoomJoined: handleSocketRoomJoined,
     onReceiveMessage: handleSocketReceiveMessage,
     onRoomParticipants: handleSocketParticipants,
+    onNotificationCreated: handleSocketNotificationCreated,
+    onNotificationRead: handleSocketNotificationRead,
     onError: handleSocketError,
   })
 
@@ -536,4 +549,5 @@ function AppShell() {
 }
 
 export default AppShell
+
 

--- a/src/features/chat/hooks/useChatSocket.js
+++ b/src/features/chat/hooks/useChatSocket.js
@@ -10,6 +10,8 @@ export const useChatSocket = ({
   onRoomJoined,
   onReceiveMessage,
   onRoomParticipants,
+  onNotificationCreated,
+  onNotificationRead,
   onError,
 }) => {
   const socketRef = useRef(null)
@@ -79,9 +81,18 @@ export const useChatSocket = ({
       onRoomParticipants?.(Array.isArray(payload?.participants) ? payload.participants : [])
     })
 
+    // 메시지는 현재 방 여부와 상관없이 AppShell까지 모두 전달한다.
+    // 현재 방이면 본문에 append하고, 다른 방이면 목록 unread만 갱신하는 쪽이 상위 레벨에서 더 안전하다.
     client.on('receive_message', (payload) => {
-      if (payload?.chatRoomId !== currentRoomRef.current) return
       onReceiveMessage?.(payload)
+    })
+
+    client.on('notification_created', (payload) => {
+      onNotificationCreated?.(payload?.notification || payload)
+    })
+
+    client.on('notification_read', (payload) => {
+      onNotificationRead?.(payload?.notification || payload)
     })
 
     client.on('error', (payload) => {
@@ -103,6 +114,8 @@ export const useChatSocket = ({
     isAuthInitializing,
     onConnect,
     onError,
+    onNotificationCreated,
+    onNotificationRead,
     onReceiveMessage,
     onRoomJoined,
     onRoomParticipants,


### PR DESCRIPTION
Title  
`fix(socket): sync realtime messages and notifications`

Summary  
실시간 메시지와 알림이 새로고침 없이 반영되도록 소켓 흐름을 수정했습니다. 메시지는 현재 방/다른 방을 상위 레벨에서 나눠 처리하게 바꾸고, 알림 소켓 이벤트도 프론트에 연결

Changed Files  
- [AppShell.jsx](c:/Users/yoooo/flownium-chat-2.0/src/app/AppShell.jsx)
- [useChatSocket.js](c:/Users/yoooo/flownium-chat-2.0/src/features/chat/hooks/useChatSocket.js)

What’s Included  
- `receive_message` 현재 방 필터 제거
- 현재 방 메시지는 본문에 즉시 append
- 다른 방 메시지는 방 목록 unread만 갱신
- `notification_created` 이벤트 수신 추가
- `notification_read` 이벤트 수신 추가
- 알림 이벤트 수신 시 `fetchNotifications()` 재호출

Impact  
- 내가 보낸 메시지와 상대 메시지가 새로고침 없이 화면에 반영됨
- 다른 방에서 온 메시지는 방 목록 unread가 즉시 갱신됨
- 친구 요청/방 초대 알림도 새로고침 없이 허브에 반영될 수 있는 구조로 정리됨

Validation  
- `npm run build` 통과

Branch / Commit  
- Branch: `fix/realtime-message-notification-sync`
- Commit: `8f1dda0`
- Push: `origin/fix/realtime-message-notification-sync` 완료

PR  
- `https://github.com/yoooon0104/flownium-chat-2.0/pull/new/fix/realtime-message-notification-sync`
- Compare 링크: `https://github.com/yoooon0104/flownium-chat-2.0/compare/main...fix/realtime-message-notification-sync?expand=1`