### PR TITLE
fix(realtime): sync friendship and notification socket updates

### DIFF
--- a/server/index.cjs
+++ b/server/index.cjs
@@ -119,6 +119,12 @@ const emitNotificationRead = (userId, notification) => {
   });
 };
 
+// 친구 요청/수락/거절은 요청자와 대상자 화면이 동시에 바뀐다.
+// 세부 항목을 직접 patch하는 대신, 양쪽이 목록을 다시 읽도록 최소 이벤트만 보낸다.
+const emitFriendshipUpdated = (userId, payload = {}) => {
+  io.to(`user:${String(userId)}`).emit('friendship_updated', payload);
+};
+
 const addPresence = (roomId, userId, socketId) => {
   if (!roomPresence.has(roomId)) {
     roomPresence.set(roomId, new Map());
@@ -275,6 +281,7 @@ app.use(
     requireAuth,
     assertDbConnected,
     emitNotificationCreated,
+    emitFriendshipUpdated,
   })
 );
 
@@ -287,6 +294,7 @@ app.use(
     requireAuth,
     assertDbConnected,
     emitNotificationCreated,
+    emitFriendshipUpdated,
   })
 );
 
@@ -456,4 +464,9 @@ start().catch((error) => {
   console.error('Failed to start server:', error.message);
   process.exit(1);
 });
+
+
+
+
+
 

--- a/server/routes/friend.routes.cjs
+++ b/server/routes/friend.routes.cjs
@@ -1,7 +1,8 @@
-const express = require("express");
+﻿const express = require("express");
 const { sendError } = require("../utils/error-response.cjs");
 
-// 친구 관계 REST API를 생성한다. 검색, 요청, 상태 처리만 담당한다.
+// 친구 관계 REST API를 생성한다.
+// 검색, 요청 생성, 상태 변경만 담당하고, 실시간 동기화는 emit 콜백으로 위임한다.
 const createFriendRouter = ({
   User,
   Friendship,
@@ -9,6 +10,7 @@ const createFriendRouter = ({
   requireAuth,
   assertDbConnected,
   emitNotificationCreated,
+  emitFriendshipUpdated,
 }) => {
   const router = express.Router();
 
@@ -55,7 +57,7 @@ const createFriendRouter = ({
     return notification;
   };
 
-  // 친구 검색은 이메일 또는 닉네임 기준으로 수행하고 현재 친구 상태를 함께 내려준다.
+  // 친구 검색은 이메일/닉네임 기준으로 수행하고, 현재 친구 상태를 함께 내려준다.
   router.get("/friends/search", requireAuth, async (req, res) => {
     const me = req.user.userId;
     const keyword = String(req.query.keyword || "").trim();
@@ -227,6 +229,16 @@ const createFriendRouter = ({
         },
       });
 
+      // 요청을 보낸 사람과 받은 사람 모두 Friends/알림 목록을 즉시 다시 가져오게 한다.
+      emitFriendshipUpdated?.(me, {
+        type: "friend_request_created",
+        friendshipId: String(friendship._id),
+      });
+      emitFriendshipUpdated?.(targetUserId, {
+        type: "friend_request_created",
+        friendshipId: String(friendship._id),
+      });
+
       res.status(201).json({
         friendship: {
           id: String(friendship._id),
@@ -290,6 +302,18 @@ const createFriendRouter = ({
       }
 
       await friendship.save();
+
+      // 상태가 바뀌면 요청 당사자 둘 다 목록 구조가 변하므로 양쪽에 동시에 갱신 이벤트를 보낸다.
+      emitFriendshipUpdated?.(requesterId, {
+        type: "friend_request_updated",
+        friendshipId: String(friendship._id),
+        status: friendship.status,
+      });
+      emitFriendshipUpdated?.(addresseeId, {
+        type: "friend_request_updated",
+        friendshipId: String(friendship._id),
+        status: friendship.status,
+      });
 
       res.status(200).json({
         friendship: {

--- a/src/app/AppShell.jsx
+++ b/src/app/AppShell.jsx
@@ -236,6 +236,12 @@ function AppShell() {
     void fetchNotifications()
   }, [fetchNotifications])
 
+  // 친구 요청/수락/거절은 Friends와 알림 허브를 함께 바꾸므로 둘 다 다시 조회한다.
+  const handleSocketFriendshipUpdated = useCallback(() => {
+    void fetchFriends()
+    void fetchNotifications()
+  }, [fetchFriends, fetchNotifications])
+
   const handleSocketError = useCallback((message) => {
     setErrorMessage(message)
   }, [setErrorMessage])
@@ -257,6 +263,7 @@ function AppShell() {
     onRoomParticipants: handleSocketParticipants,
     onNotificationCreated: handleSocketNotificationCreated,
     onNotificationRead: handleSocketNotificationRead,
+    onFriendshipUpdated: handleSocketFriendshipUpdated,
     onError: handleSocketError,
   })
 
@@ -598,6 +605,8 @@ function AppShell() {
 }
 
 export default AppShell
+
+
 
 
 

--- a/src/features/chat/hooks/useChatSocket.js
+++ b/src/features/chat/hooks/useChatSocket.js
@@ -12,6 +12,7 @@ export const useChatSocket = ({
   onRoomParticipants,
   onNotificationCreated,
   onNotificationRead,
+  onFriendshipUpdated,
   onError,
 }) => {
   const socketRef = useRef(null)
@@ -95,6 +96,11 @@ export const useChatSocket = ({
       onNotificationRead?.(payload?.notification || payload)
     })
 
+    // 친구 요청/수락/거절은 양쪽 목록을 다시 그려야 하므로 최소 이벤트만 전달한다.
+    client.on('friendship_updated', (payload) => {
+      onFriendshipUpdated?.(payload || {})
+    })
+
     client.on('error', (payload) => {
       const code = String(payload?.code || '').trim()
       const message = String(payload?.message || 'Unknown socket error')
@@ -116,6 +122,7 @@ export const useChatSocket = ({
     onError,
     onNotificationCreated,
     onNotificationRead,
+    onFriendshipUpdated,
     onReceiveMessage,
     onRoomJoined,
     onRoomParticipants,


### PR DESCRIPTION
Title  
`fix(realtime): sync friendship and notification socket updates`

Summary  
친구 요청/수락/거절, 알림 허브, 다른 방 메시지 갱신이 새로고침 없이 반영되도록 소켓 이벤트 흐름을 정리했다. 프론트는 `friendship_updated`를 받아 Friends/알림 목록을 재조회하고, 서버는 친구 상태 변경 시 양쪽 사용자에게 실시간 이벤트를 보낸다.

Changed Files  
- [index.cjs](c:/Users/yoooo/flownium-chat-2.0/server/index.cjs)
- [friend.routes.cjs](c:/Users/yoooo/flownium-chat-2.0/server/routes/friend.routes.cjs)
- [AppShell.jsx](c:/Users/yoooo/flownium-chat-2.0/src/app/AppShell.jsx)
- [useChatSocket.js](c:/Users/yoooo/flownium-chat-2.0/src/features/chat/hooks/useChatSocket.js)

What’s Included  
- 서버 `friendship_updated` 이벤트 추가
- 친구 요청 생성 시 요청자/대상자 양쪽에 갱신 이벤트 전송
- 친구 요청 수락/거절/차단 시 양쪽에 갱신 이벤트 전송
- 프론트 `useChatSocket`에 `friendship_updated` 리스너 추가
- `AppShell`에서 친구 이벤트 수신 시 `fetchFriends()` + `fetchNotifications()` 재호출
- 기존 `notification_created`, `notification_read`, `receive_message` 흐름과 함께 동작하도록 정리
- `friend.routes.cjs` 한글 주석/인코딩 UTF-8 재정리

Impact  
- 친구 요청/수락/거절이 상대 화면에 새로고침 없이 반영될 수 있는 구조
- 알림 허브 갱신과 친구 목록 갱신이 한 흐름으로 묶임
- 현재 방/다른 방 메시지 갱신과 실시간 동기화 구조가 더 일관됨

Validation  
- `node --check server/index.cjs` 통과
- `node --check server/routes/friend.routes.cjs` 통과
- `npm run build` 통과

Branch / Commit  
- Branch: `fix/realtime-sync-gap`
- Commit: `9dec48c`
- Push: `origin/fix/realtime-sync-gap` 완료

PR  
- `https://github.com/yoooon0104/flownium-chat-2.0/pull/new/fix/realtime-sync-gap`
- Compare 링크: `https://github.com/yoooon0104/flownium-chat-2.0/compare/main...fix/realtime-sync-gap?expand=1`