### PR TITLE
fix(chat): stabilize optimistic unread rendering

### DIFF
--- a/src/app/AppShell.jsx
+++ b/src/app/AppShell.jsx
@@ -314,39 +314,6 @@ function AppShell() {
     emitJoinRoom(roomId)
   }, [emitJoinRoom, setErrorMessage])
 
-  const handleSendMessage = useCallback(() => {
-    const normalized = text.trim()
-    if (!joinedRoomId || !normalized) return
-
-    // 입력 직후 화면에 먼저 보여줄 임시 메시지 ID를 만든다.
-    // 서버 응답이 오면 같은 clientMessageId를 기준으로 실제 메시지로 교체한다.
-    const clientMessageId = `local-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
-    appendMessage({
-      clientMessageId,
-      id: clientMessageId,
-      chatRoomId: joinedRoomId,
-      senderId: currentUser?.id || '',
-      senderNickname: currentUser?.nickname || '?',
-      type: 'text',
-      text: normalized,
-      timestamp: new Date().toISOString(),
-      unreadCount: 0,
-    })
-
-    sendMessage({
-      roomId: joinedRoomId,
-      text: normalized,
-      type: 'text',
-      clientMessageId,
-    })
-    setText('')
-  }, [appendMessage, currentUser?.id, currentUser?.nickname, joinedRoomId, sendMessage, text])
-
-  const handleComposerKeyUp = useCallback((event) => {
-    if (event.key === 'Enter') {
-      handleSendMessage()
-    }
-  }, [handleSendMessage])
 
   const handleCreateRoomSubmit = useCallback(async (payload) => {
     const result = await createRoom(payload)
@@ -390,7 +357,56 @@ function AppShell() {
     return rooms.find((room) => room.id === joinedRoomId) || null
   }, [rooms, joinedRoomId])
 
+  const optimisticUnreadCount = useMemo(() => {
+    const roomMemberCount = Array.isArray(activeRoom?.memberIds)
+      ? activeRoom.memberIds.length
+      : Array.isArray(participants)
+        ? participants.length
+        : 0
+
+    return Math.max(roomMemberCount - 1, 0)
+  }, [activeRoom?.memberIds, participants])
+
+
   const canSend = Boolean(isConnected && joinedRoomId && text.trim().length > 0)
+
+  const handleSendMessage = useCallback(() => {
+    const normalized = text.trim()
+    if (!joinedRoomId || !normalized) return
+
+    // ?? ?? ??? ?? ??? ?? ??? ID? ???.
+    // ?? ??? ?? ?? clientMessageId? ???? ?? ???? ????.
+    // ? ?? ?? ???? unread ??? ???? ?? ? ?? ? ?? ?? ?? ???.
+    const clientMessageId = `local-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    appendMessage({
+      clientMessageId,
+      id: clientMessageId,
+      chatRoomId: joinedRoomId,
+      senderId: currentUser?.id || '',
+      senderNickname: currentUser?.nickname || '?',
+      type: 'text',
+      text: normalized,
+      timestamp: new Date().toISOString(),
+      unreadCount: optimisticUnreadCount,
+    })
+
+    sendMessage({
+      roomId: joinedRoomId,
+      text: normalized,
+      type: 'text',
+      clientMessageId,
+    })
+    setText('')
+  }, [appendMessage, currentUser?.id, currentUser?.nickname, joinedRoomId, optimisticUnreadCount, sendMessage, text])
+
+  const handleComposerKeyUp = useCallback((event) => {
+    if (event.key === 'Enter') {
+      handleSendMessage()
+    }
+  }, [handleSendMessage])
+
+
+
 
   // 모바일 하단 탭바는 현재 어떤 1차 화면을 보고 있는지에 따라 활성 상태를 바꾼다.
   // 알림 화면이 열려 있으면 notifications를 우선으로 보고, 그 외에는 Friends/Rooms 탭 상태를 그대로 따른다.
@@ -625,6 +641,7 @@ function AppShell() {
 }
 
 export default AppShell
+
 
 
 


### PR DESCRIPTION
Title  
`fix(chat): stabilize optimistic unread rendering`

Summary  
`AppShell`의 optimistic 전송 흐름을 정리해서 초기 렌더 깨짐 없이 
마지막 전송 메시지에도 unread 숫자가 바로 붙도록 브랜치에 반영하고 푸시

Changed Files  
- [AppShell.jsx](c:/Users/yoooo/flownium-chat-2.0/src/app/AppShell.jsx)

What’s Included  
- `optimisticUnreadCount` 계산 추가
- 임시 메시지 append 시 예상 unreadCount 선반영
- `handleSendMessage`와 `handleComposerKeyUp` 선언 순서 정리
- 마지막 전송 메시지에서 unread 숫자 즉시 표시되도록 보정

Impact  
- 첫 화면 렌더 안정화
- 마지막 전송 메시지 unread 숫자 즉시 표시
- optimistic 메시지 UX 안정화

Validation  
- `npm run build` 통과
- 로컬 렌더 정상 확인
- 브랜치 푸시 완료

Branch / Commit  
- Branch: `fix/optimistic-message-and-checklist`
- Commit: `dd38bbc`
- Push: `origin/fix/optimistic-message-and-checklist` 완료

PR  
- `https://github.com/yoooon0104/flownium-chat-2.0/pull/new/fix/optimistic-message-and-checklist`
- Compare 링크: `https://github.com/yoooon0104/flownium-chat-2.0/compare/main...fix/optimistic-message-and-checklist?expand=1`