### PR TITLE
fix(chat): ack optimistic message sends

### DIFF
--- a/docs/common/socket-events.md
+++ b/docs/common/socket-events.md
@@ -27,7 +27,8 @@
 {
   "roomId": "chatroomObjectId",
   "text": "message text",
-  "type": "text"
+  "type": "text",
+  "clientMessageId": "local-1710057600000-ab12cd"
 }
 ```
 
@@ -35,6 +36,26 @@
 - 메시지 DB 저장
 - 방의 `lastMessage`, `lastMessageAt` 갱신
 - `receive_message` 브로드캐스트
+- ack 응답으로 전송 성공/실패를 호출자에게 즉시 반환
+
+ack 성공:
+```json
+{
+  "ok": true,
+  "clientMessageId": "local-1710057600000-ab12cd",
+  "messageId": "messageId"
+}
+```
+
+ack 실패:
+```json
+{
+  "ok": false,
+  "code": "DB_NOT_CONNECTED",
+  "message": "database is not connected",
+  "clientMessageId": "local-1710057600000-ab12cd"
+}
+```
 
 ## 서버 -> 클라이언트
 
@@ -72,6 +93,7 @@
 ### receive_message
 ```json
 {
+  "clientMessageId": "local-1710057600000-ab12cd",
   "id": "messageId",
   "chatRoomId": "chatroomObjectId",
   "senderId": "u1",
@@ -84,6 +106,7 @@
 ```
 
 규칙:
+- 보낸 사람에게는 같은 `clientMessageId`가 다시 전달되어 optimistic 메시지를 실제 메시지로 치환할 수 있음
 - `unreadCount`는 해당 메시지를 아직 읽지 않은 상대 인원 수
 - 모두 읽었으면 `0`
 - 채팅창에서는 숫자만 노출하고 0은 숨김

--- a/server/index.cjs
+++ b/server/index.cjs
@@ -367,19 +367,32 @@ io.on('connection', (socket) => {
     }
   });
 
-  socket.on('send_message', async (payload = {}) => {
+  socket.on('send_message', async (payload = {}, ack) => {
     const roomId = String(payload.roomId || '').trim();
     const text = String(payload.text || '').trim();
     const type = payload.type === 'system' ? 'system' : 'text';
     const clientMessageId = String(payload.clientMessageId || '').trim();
+    const reply = typeof ack === 'function' ? ack : () => {};
 
     if (!roomId || !text) {
       emitSocketError(socket, 'INVALID_REQUEST', 'roomId and text are required');
+      reply({
+        ok: false,
+        code: 'INVALID_REQUEST',
+        message: 'roomId and text are required',
+        clientMessageId: clientMessageId || null,
+      });
       return;
     }
 
     if (mongoose.connection.readyState !== 1) {
       emitSocketError(socket, 'DB_NOT_CONNECTED', 'database is not connected');
+      reply({
+        ok: false,
+        code: 'DB_NOT_CONNECTED',
+        message: 'database is not connected',
+        clientMessageId: clientMessageId || null,
+      });
       return;
     }
 
@@ -387,11 +400,23 @@ io.on('connection', (socket) => {
       const room = await ChatRoom.findById(roomId);
       if (!room) {
         emitSocketError(socket, 'ROOM_NOT_FOUND', 'chatroom not found');
+        reply({
+          ok: false,
+          code: 'ROOM_NOT_FOUND',
+          message: 'chatroom not found',
+          clientMessageId: clientMessageId || null,
+        });
         return;
       }
 
       if (!room.memberIds.includes(socket.user.userId)) {
         emitSocketError(socket, 'FORBIDDEN', 'forbidden');
+        reply({
+          ok: false,
+          code: 'FORBIDDEN',
+          message: 'forbidden',
+          clientMessageId: clientMessageId || null,
+        });
         return;
       }
 
@@ -435,8 +460,20 @@ io.on('connection', (socket) => {
         timestamp: new Date(message.timestamp).toISOString(),
         unreadCount,
       });
+
+      reply({
+        ok: true,
+        clientMessageId: clientMessageId || null,
+        messageId: String(message._id),
+      });
     } catch (_error) {
       emitSocketError(socket, 'MESSAGE_PROCESS_FAILED', 'failed to process message');
+      reply({
+        ok: false,
+        code: 'MESSAGE_PROCESS_FAILED',
+        message: 'failed to process message',
+        clientMessageId: clientMessageId || null,
+      });
     }
   });
 

--- a/src/app/AppShell.jsx
+++ b/src/app/AppShell.jsx
@@ -107,6 +107,7 @@ function AppShell() {
     historyError,
     loadMessageHistory,
     appendMessage,
+    removeMessageByClientMessageId,
     clearMessages,
   } = useChatMessages({ chatApi })
 
@@ -366,15 +367,15 @@ function AppShell() {
   const optimisticUnreadCount = Math.max(roomMemberCount - 1, 0)
 
 
-  const canSend = Boolean(isConnected && joinedRoomId && text.trim().length > 0)
+  const canSend = Boolean(isConnected && joinedRoomId && !isLoadingHistory && text.trim().length > 0)
 
-  const handleSendMessage = useCallback(() => {
+  const handleSendMessage = useCallback(async () => {
     const normalized = text.trim()
-    if (!joinedRoomId || !normalized) return
+    if (!joinedRoomId || !normalized || isLoadingHistory) return
 
-    // 서버 응답 전에도 화면에 즉시 메시지를 보여주기 위해 임시 메시지 ID를 만든다.
-    // 이후 서버가 같은 clientMessageId를 돌려주면 optimistic 메시지를 실제 메시지로 치환한다.
-    // unreadCount도 이 시점에 예상값을 먼저 붙여서 마지막 보낸 메시지에 숫자가 바로 보이게 한다.
+    // 히스토리 로딩이 끝난 뒤에만 optimistic 메시지를 붙여야
+    // 직후 도착한 과거 메시지 응답이 방금 보낸 메시지를 덮어쓰지 않는다.
+    // 실패/타임아웃 시에는 같은 clientMessageId로 optimistic 메시지를 제거한다.
     const clientMessageId = `local-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
     appendMessage({
       clientMessageId,
@@ -388,14 +389,32 @@ function AppShell() {
       unreadCount: optimisticUnreadCount,
     })
 
-    sendMessage({
+    setText('')
+
+    const result = await sendMessage({
       roomId: joinedRoomId,
       text: normalized,
       type: 'text',
       clientMessageId,
     })
-    setText('')
-  }, [appendMessage, currentUser?.id, currentUser?.nickname, joinedRoomId, optimisticUnreadCount, sendMessage, text])
+
+    if (result?.ok) return
+
+    removeMessageByClientMessageId(clientMessageId)
+    setText(normalized)
+    setErrorMessage(String(result?.message || '메시지 전송에 실패했습니다.'))
+  }, [
+    appendMessage,
+    currentUser?.id,
+    currentUser?.nickname,
+    isLoadingHistory,
+    joinedRoomId,
+    optimisticUnreadCount,
+    removeMessageByClientMessageId,
+    sendMessage,
+    setErrorMessage,
+    text,
+  ])
 
   const handleComposerKeyUp = useCallback((event) => {
     if (event.key === 'Enter') {

--- a/src/features/chat/hooks/useChatMessages.js
+++ b/src/features/chat/hooks/useChatMessages.js
@@ -49,6 +49,14 @@ export const useChatMessages = ({ chatApi }) => {
     })
   }, [])
 
+  const removeMessageByClientMessageId = useCallback((clientMessageId) => {
+    if (!clientMessageId) return
+
+    setMessages((prev) => {
+      return prev.filter((item) => item?.clientMessageId !== clientMessageId)
+    })
+  }, [])
+
   const clearMessages = useCallback(() => {
     setMessages([])
     setHistoryError('')
@@ -62,6 +70,7 @@ export const useChatMessages = ({ chatApi }) => {
     setHistoryError,
     loadMessageHistory,
     appendMessage,
+    removeMessageByClientMessageId,
     clearMessages,
   }
 }

--- a/src/features/chat/hooks/useChatSocket.js
+++ b/src/features/chat/hooks/useChatSocket.js
@@ -136,8 +136,39 @@ export const useChatSocket = ({
   }, [])
 
   const sendMessage = useCallback((payload) => {
-    if (!socketRef.current) return
-    socketRef.current.emit('send_message', payload)
+    if (!socketRef.current) {
+      return Promise.resolve({
+        ok: false,
+        code: 'SOCKET_NOT_CONNECTED',
+        message: 'Socket is not connected.',
+      })
+    }
+
+    return new Promise((resolve) => {
+      let isSettled = false
+      const finish = (result) => {
+        if (isSettled) return
+        isSettled = true
+        clearTimeout(timeoutId)
+        resolve(result)
+      }
+
+      const timeoutId = setTimeout(() => {
+        finish({
+          ok: false,
+          code: 'SEND_MESSAGE_TIMEOUT',
+          message: 'Message send acknowledgement timed out.',
+        })
+      }, 5000)
+
+      socketRef.current.emit('send_message', payload, (response) => {
+        finish(response || {
+          ok: false,
+          code: 'SEND_MESSAGE_ACK_EMPTY',
+          message: 'Message acknowledgement was empty.',
+        })
+      })
+    })
   }, [])
 
   return {


### PR DESCRIPTION
**Title**  
fix(chat): stabilize optimistic send with history-load guard and socket ack

**Summary**  
방 입장 직후 히스토리 로딩과 optimistic 전송이 충돌해 메시지가 사라질 수 있던 경쟁 상태를 막았습니다.  
또한 `send_message` 실패나 ack 타임아웃 시 optimistic 메시지가 화면에 남지 않도록 롤백 경로를 추가했습니다.

**Changed Files**  
- [src/app/AppShell.jsx](C:\Users\yoooo\flownium-chat-2.0\src\app\AppShell.jsx)
- [src/features/chat/hooks/useChatMessages.js](C:\Users\yoooo\flownium-chat-2.0\src\features\chat\hooks\useChatMessages.js)
- [src/features/chat/hooks/useChatSocket.js](C:\Users\yoooo\flownium-chat-2.0\src\features\chat\hooks\useChatSocket.js)
- [server/index.cjs](C:\Users\yoooo\flownium-chat-2.0\server\index.cjs)
- [docs/common/socket-events.md](C:\Users\yoooo\flownium-chat-2.0\docs\common\socket-events.md)

**What’s Included**  
- 히스토리 로딩 중에는 메시지 전송을 막아 optimistic 메시지가 뒤늦은 history 응답에 덮이지 않게 했습니다.
- optimistic 메시지 제거용 `removeMessageByClientMessageId`를 추가했습니다.
- 클라이언트 `send_message`를 ack Promise 기반으로 바꿨고, 5초 timeout도 넣었습니다.
- 서버 `send_message`에 성공/실패 ack를 추가했습니다.
- 실패 시 optimistic 메시지를 제거하고 입력값을 복원하도록 연결했습니다.
- 소켓 명세 문서에 `clientMessageId`와 ack 응답을 반영했습니다.

**Impact**  
- 채팅 입력/실시간 메시지 처리
- Socket.IO `send_message` 호출 경로
- 소켓 이벤트 문서

**Validation**  
- `npm run build` 통과
- `node --check server/index.cjs` 통과
- 내부 diff 리뷰: 추가 actionable issue 없음

**Branch / Commit**  
- Branch: `docs/codex-and-rules-sync`
- Commit: `ae6be6a`
- Push: 수행하지 않음