### PR TITLE
fix(chat): update unread counts after room reads

### DIFF
--- a/docs/common/socket-events.md
+++ b/docs/common/socket-events.md
@@ -144,6 +144,25 @@ ack 실패:
 - 채팅창에서는 숫자만 노출하고 0은 숨김
 - `type: "system"` 메시지는 입장/퇴장 lifecycle 기록에 사용
 
+### message_updated
+```json
+{
+  "id": "messageId",
+  "chatRoomId": "chatroomObjectId",
+  "senderId": "u1",
+  "senderNickname": "alice",
+  "type": "text",
+  "text": "hello",
+  "timestamp": "2026-03-05T10:00:00.000Z",
+  "unreadCount": 0
+}
+```
+
+규칙:
+- 기존 메시지와 같은 `id`를 사용해 unread count 같은 후속 상태만 갱신
+- 주로 읽음 처리 후 해당 메시지들의 unread count 재계산 결과를 브로드캐스트
+- 프론트는 새 메시지로 추가하지 말고 같은 `id` 메시지에 merge해야 함
+
 ### notification_created
 ```json
 {

--- a/server/index.cjs
+++ b/server/index.cjs
@@ -248,7 +248,7 @@ const disconnectUserFromRoom = async (roomId, userId) => {
   });
 };
 
-const emitRoomMessage = async (roomDoc, messageDoc, clientMessageId = null) => {
+const buildRealtimeMessagePayload = async (roomDoc, messageDoc, clientMessageId = null) => {
   const roomId = String(roomDoc._id || roomDoc.id || messageDoc.chatRoomId);
   const memberIds = Array.isArray(roomDoc.memberIds) ? roomDoc.memberIds.map((value) => String(value)) : [];
   const targetReadStates = await ChatReadState.find({
@@ -266,7 +266,7 @@ const emitRoomMessage = async (roomDoc, messageDoc, clientMessageId = null) => {
     return new Date(readState.lastReadAt) < messageTimestamp;
   }).length;
 
-  io.to(roomId).emit('receive_message', {
+  return {
     clientMessageId,
     id: String(messageDoc._id),
     chatRoomId: roomId,
@@ -276,7 +276,17 @@ const emitRoomMessage = async (roomDoc, messageDoc, clientMessageId = null) => {
     text: messageDoc.text,
     timestamp: messageTimestamp.toISOString(),
     unreadCount,
-  });
+  };
+};
+
+const emitRoomMessage = async (roomDoc, messageDoc, clientMessageId = null) => {
+  const payload = await buildRealtimeMessagePayload(roomDoc, messageDoc, clientMessageId);
+  io.to(payload.chatRoomId).emit('receive_message', payload);
+};
+
+const emitMessageUpdated = async (roomDoc, messageDoc) => {
+  const payload = await buildRealtimeMessagePayload(roomDoc, messageDoc);
+  io.to(payload.chatRoomId).emit('message_updated', payload);
 };
 
 io.use((socket, next) => {
@@ -343,6 +353,7 @@ app.use(
     emitRoomDeleted,
     emitRoomParticipants,
     emitRoomMessage,
+    emitMessageUpdated,
     disconnectUserFromRoom,
   })
 );

--- a/server/routes/chatroom.routes.cjs
+++ b/server/routes/chatroom.routes.cjs
@@ -17,6 +17,7 @@ const createChatroomRouter = ({
   emitRoomDeleted,
   emitRoomParticipants,
   emitRoomMessage,
+  emitMessageUpdated,
   disconnectUserFromRoom,
 }) => {
   const router = express.Router();
@@ -621,11 +622,33 @@ const createChatroomRouter = ({
         return;
       }
 
+      const previousReadState = await ChatReadState.findOne({
+        roomId,
+        userId: req.user.userId,
+      }).lean();
+
       const readState = await ChatReadState.findOneAndUpdate(
         { roomId, userId: req.user.userId },
         { $set: { lastReadAt: new Date() } },
         { new: true, upsert: true, setDefaultsOnInsert: true }
       ).lean();
+
+      const affectedMessagesQuery = {
+        chatRoomId: roomId,
+        senderId: { $ne: req.user.userId },
+      }
+
+      if (previousReadState?.lastReadAt) {
+        affectedMessagesQuery.timestamp = { $gt: previousReadState.lastReadAt }
+      }
+
+      const affectedMessages = await Message.find(affectedMessagesQuery)
+        .sort({ timestamp: 1 })
+        .lean()
+
+      await Promise.all(
+        affectedMessages.map((message) => emitMessageUpdated?.(room, message))
+      )
 
       res.status(200).json({
         roomId,

--- a/src/app/AppShell.jsx
+++ b/src/app/AppShell.jsx
@@ -238,6 +238,11 @@ function AppShell() {
     })()
   }, [appendMessage, currentUser?.id, fetchRooms, joinedRoomId, markRoomRead])
 
+  const handleSocketMessageUpdated = useCallback((message) => {
+    if (message?.chatRoomId !== joinedRoomId) return
+    appendMessage(message)
+  }, [appendMessage, joinedRoomId])
+
   const handleSocketParticipants = useCallback((nextParticipants) => {
     setParticipants(nextParticipants)
   }, [])
@@ -298,6 +303,7 @@ function AppShell() {
     onUnauthorized: handleSocketUnauthorized,
     onRoomJoined: handleSocketRoomJoined,
     onReceiveMessage: handleSocketReceiveMessage,
+    onMessageUpdated: handleSocketMessageUpdated,
     onRoomParticipants: handleSocketParticipants,
     onRoomUpdated: handleSocketRoomUpdated,
     onRoomDeleted: handleSocketRoomDeleted,

--- a/src/features/chat/components/InviteFriendsModal.jsx
+++ b/src/features/chat/components/InviteFriendsModal.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 
 // 방 초대 모달은 현재 방 멤버를 제외한 친구만 보여준다.
-// 1:1/다인방 여부는 서버가 판단하므로 여기서는 선택과 제출만 담당한다.
+// 기존 direct/group 여부와 무관하게 초대 대상 선택과 제출만 담당한다.
 function InviteFriendsModal({ isOpen, friends, roomName, errorMessage, onClose, onSubmit }) {
   const [selectedIds, setSelectedIds] = useState([])
   const [localError, setLocalError] = useState('')
@@ -72,6 +72,8 @@ function InviteFriendsModal({ isOpen, friends, roomName, errorMessage, onClose, 
           {friends.length === 0 && <li className="state-item friend-picker-empty">초대 가능한 친구가 없습니다.</li>}
           {friends.map((friend) => {
             const isSelected = selectedIds.includes(friend.id)
+            const fallbackName = String(friend.nickname || '').trim() || '이름 없음'
+            const fallbackEmail = String(friend.email || '').trim() || '이메일 미등록'
             return (
               <li key={friend.id}>
                 <button
@@ -80,11 +82,11 @@ function InviteFriendsModal({ isOpen, friends, roomName, errorMessage, onClose, 
                   onClick={() => toggleFriend(friend.id)}
                 >
                   <span className="friend-avatar">
-                    {friend.profileImage ? <img src={friend.profileImage} alt="" /> : friend.nickname.slice(0, 1).toUpperCase()}
+                    {friend.profileImage ? <img src={friend.profileImage} alt="" /> : fallbackName.slice(0, 1).toUpperCase()}
                   </span>
                   <span className="friend-main">
-                    <strong>{friend.nickname || '이름 없음'}</strong>
-                    <small>{friend.email || '이메일 미등록'}</small>
+                    <strong>{fallbackName}</strong>
+                    <small>{fallbackEmail}</small>
                   </span>
                   <span className={`selection-indicator ${isSelected ? 'checked' : ''}`}>{isSelected ? '선택' : ''}</span>
                 </button>
@@ -97,7 +99,9 @@ function InviteFriendsModal({ isOpen, friends, roomName, errorMessage, onClose, 
 
         <div className="selected-friends-summary">
           {selectedFriends.map((friend) => (
-            <span key={friend.id} className="selected-friend-chip">{friend.nickname || '이름 없음'}</span>
+            <span key={friend.id} className="selected-friend-chip">
+              {String(friend.nickname || '').trim() || '이름 없음'}
+            </span>
           ))}
         </div>
 

--- a/src/features/chat/hooks/useChatMessages.js
+++ b/src/features/chat/hooks/useChatMessages.js
@@ -42,7 +42,10 @@ export const useChatMessages = ({ chatApi }) => {
       }
 
       if (message?.id && prev.some((item) => item?.id === message.id)) {
-        return prev
+        return prev.map((item) => {
+          if (item?.id !== message.id) return item
+          return { ...item, ...message }
+        })
       }
 
       return [...prev, message]

--- a/src/features/chat/hooks/useChatSocket.js
+++ b/src/features/chat/hooks/useChatSocket.js
@@ -9,6 +9,7 @@ export const useChatSocket = ({
   onUnauthorized,
   onRoomJoined,
   onReceiveMessage,
+  onMessageUpdated,
   onRoomParticipants,
   onRoomUpdated,
   onRoomDeleted,
@@ -98,6 +99,11 @@ export const useChatSocket = ({
       onReceiveMessage?.(payload)
     })
 
+    client.on('message_updated', (payload) => {
+      if (String(payload?.chatRoomId || '') !== currentRoomRef.current) return
+      onMessageUpdated?.(payload)
+    })
+
     client.on('notification_created', (payload) => {
       onNotificationCreated?.(payload?.notification || payload)
     })
@@ -135,6 +141,7 @@ export const useChatSocket = ({
     onNotificationCreated,
     onNotificationRead,
     onFriendshipUpdated,
+    onMessageUpdated,
     onReceiveMessage,
     onRoomJoined,
     onRoomParticipants,


### PR DESCRIPTION
## Summary
- update unread counts in group chat after participants read messages
- merge message updates by message id instead of ignoring duplicate payloads
- clean up InviteFriendsModal labels and fallback text

## Changed Files
- docs/common/socket-events.md
- server/index.cjs
- server/routes/chatroom.routes.cjs
- src/app/AppShell.jsx
- src/features/chat/components/InviteFriendsModal.jsx
- src/features/chat/hooks/useChatMessages.js
- src/features/chat/hooks/useChatSocket.js

## Validation
- npm run build
- node --check server/index.cjs
- node --check server/routes/chatroom.routes.cjs

## Notes
- added `message_updated` socket event for read-count refreshes
- kept the change minimal to avoid altering send/read flow outside unread count sync