### PR TITLE
fix(socket): rejoin active room after reconnect

### DIFF
--- a/src/features/chat/hooks/useChatSocket.js
+++ b/src/features/chat/hooks/useChatSocket.js
@@ -45,6 +45,13 @@ export const useChatSocket = ({
     client.on('connect', () => {
       setIsConnected(true)
       setSocketId(client.id)
+
+      // 재연결 뒤에도 현재 열려 있던 방의 실시간 이벤트를 계속 받으려면
+      // 서버 기준 새 소켓 인스턴스를 다시 같은 room에 참여시켜야 한다.
+      if (currentRoomRef.current) {
+        client.emit('join_room', { roomId: currentRoomRef.current })
+      }
+
       onConnect?.()
     })
 


### PR DESCRIPTION
Title
fix(socket): rejoin active room after reconnect

Summary
Fix the active chat room losing realtime updates after an idle disconnect or transient reconnect. The socket client now rejoins the currently open room as soon as the connection is re-established.

Changed Files
- src/features/chat/hooks/useChatSocket.js

What’s Included
- rejoin the active room automatically on socket `connect`
- keep the change scoped to reconnect behavior only
- preserve the existing first-time room join flow
- Closes #37

Impact
- realtime message delivery for the active room
- reconnect behavior after idle or network interruptions

Validation
- npm run build

Branch / Commit
- Branch: codex/fix-rejoin-room-on-reconnect
- Commit: a95756e
- Push: origin/codex/fix-rejoin-room-on-reconnect

PR
- pending creation