### PR TITLE
fix(chat): refresh generated room names on invite

### DIFF
--- a/docs/common/api-spec.md
+++ b/docs/common/api-spec.md
@@ -312,6 +312,7 @@ MVP2-A 1차 표준:
 - 요청 payload의 중복 `userId`는 서버에서 dedupe
 - direct(`isGroup=false`) 방이면 기존 방을 유지하고 새 다인방을 생성
 - group(`isGroup=true`) 방이면 기존 방 `memberIds`에 즉시 멤버 추가
+- 자동 생성형 그룹명은 초대 후 현재 멤버 기준으로 다시 계산
 - 멤버 변경 시 시스템 메시지와 `lastMessage`, `lastMessageAt` 갱신
 
 요청:

--- a/server/routes/chatroom.routes.cjs
+++ b/server/routes/chatroom.routes.cjs
@@ -134,6 +134,11 @@ const createChatroomRouter = ({
     );
   };
 
+  const shouldRefreshGeneratedRoomName = (roomDoc, memberUsers) => {
+    const generatedName = buildGroupRoomName(memberUsers);
+    return String(roomDoc?.name || '').trim() === generatedName;
+  };
+
   const buildGroupRoomName = (memberUsers) => {
     const names = memberUsers
       .map((user) => String(user?.nickname || '').trim())
@@ -360,7 +365,18 @@ const createChatroomRouter = ({
           return;
         }
 
+        const existingUsers = await User.find({ _id: { $in: room.memberIds } }).lean();
+        const existingUserById = new Map(existingUsers.map((user) => [String(user._id), user]));
+        const currentMemberUsers = room.memberIds
+          .map((memberId) => existingUserById.get(String(memberId)))
+          .filter(Boolean);
+        const nextMemberUsers = [...currentMemberUsers, ...targetUsers];
+
         await seedReadStatesForInvitedUsers(room, targetUserIds);
+
+        if (shouldRefreshGeneratedRoomName(room, currentMemberUsers)) {
+          room.name = buildGroupRoomName(nextMemberUsers);
+        }
 
         room.memberIds = [...room.memberIds.map((value) => String(value)), ...targetUserIds];
         room.isGroup = true;


### PR DESCRIPTION
Title
fix(chat): refresh generated room names on invite

Summary
Keep auto-generated group room names in sync when inviting new members into an existing group room. The server now refreshes the room title only when the current name still matches the generated member-name format, so custom room names are preserved.

Changed Files
- server/routes/chatroom.routes.cjs
- docs/common/api-spec.md

What’s Included
- detect whether an existing group room is using the generated member-name title
- rebuild the room name from the updated participant list during invite when that rule applies
- leave custom/manual room names unchanged
- document the invite-name refresh behavior
- Closes #39

Impact
- group room metadata consistency
- invite flow UX
- room list and room header labels

Validation
- npm run build
- node --check server/routes/chatroom.routes.cjs

Branch / Commit
- Branch: codex/fix-group-room-name-on-invite
- Commit: 9eee48d
- Push: origin/codex/fix-group-room-name-on-invite

PR
- pending creation