### PR TITLE
fix(chat): preserve realtime updates during room resync

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -800,6 +800,7 @@
 }
 
 .message-list li.mine .bubble {
+  text-align: left;
   background: linear-gradient(92deg, #5b5cff 0%, #7a3cff 100%);
   border-color: rgba(91, 92, 255, 0.35);
   color: #f5f7ff;

--- a/src/features/chat/hooks/useChatMessages.js
+++ b/src/features/chat/hooks/useChatMessages.js
@@ -1,4 +1,40 @@
-﻿import { useCallback, useState } from 'react'
+import { useCallback, useState } from 'react'
+
+const getMessageIdentity = (message) => {
+  if (message?.id) return `id:${message.id}`
+  if (message?.clientMessageId) return `client:${message.clientMessageId}`
+  return `ts:${message?.timestamp || ''}:${message?.senderId || ''}:${message?.text || ''}`
+}
+
+const sortMessagesByTimestamp = (messages) => {
+  return [...messages].sort((left, right) => {
+    return new Date(left?.timestamp || 0).getTime() - new Date(right?.timestamp || 0).getTime()
+  })
+}
+
+const mergeMessageLists = (historyMessages, currentMessages) => {
+  const mergedByIdentity = new Map()
+
+  historyMessages.forEach((message) => {
+    mergedByIdentity.set(getMessageIdentity(message), message)
+  })
+
+  currentMessages.forEach((message) => {
+    const identity = getMessageIdentity(message)
+    const existingMessage = mergedByIdentity.get(identity)
+    if (!existingMessage) {
+      mergedByIdentity.set(identity, message)
+      return
+    }
+
+    mergedByIdentity.set(identity, {
+      ...existingMessage,
+      ...message,
+    })
+  })
+
+  return sortMessagesByTimestamp([...mergedByIdentity.values()])
+}
 
 // 메시지 히스토리 조회와 실시간 목록 업데이트를 분리한다.
 export const useChatMessages = ({ chatApi }) => {
@@ -24,7 +60,13 @@ export const useChatMessages = ({ chatApi }) => {
       return
     }
 
-    setMessages(Array.isArray(body?.messages) ? body.messages : [])
+    setMessages((prev) => {
+      const historyMessages = Array.isArray(body?.messages) ? body.messages : []
+
+      // room 재입장/재연결 직후에는 히스토리 요청과 실시간 이벤트가 겹칠 수 있다.
+      // 이때 단순 replace를 하면 방금 도착한 메시지와 read-count 갱신이 사라질 수 있으므로 merge로 보존한다.
+      return mergeMessageLists(historyMessages, prev)
+    })
     setIsLoadingHistory(false)
   }, [chatApi])
 
@@ -77,4 +119,3 @@ export const useChatMessages = ({ chatApi }) => {
     clearMessages,
   }
 }
-


### PR DESCRIPTION
## Summary
Preserve realtime chat updates that arrive while room history is being reloaded, and fix the current user's bubble text alignment.

## Changed Files
- src/features/chat/hooks/useChatMessages.js
- src/App.css

## What’s Included
- Merge history responses with in-flight realtime messages and message updates instead of replacing the current list.
- Keep own message blocks right-positioned while resetting the bubble text itself to normal left/start alignment.

## Impact
- Realtime chat rendering after room resync or reconnect
- Own-message bubble readability

## Validation
- npm install
- npm run build

Closes #41