### PR TITLE
fix(chat): place own unread count after message bubble

### DIFF
--- a/src/features/chat/components/ChatPanel.jsx
+++ b/src/features/chat/components/ChatPanel.jsx
@@ -71,10 +71,13 @@ function ChatPanel({
                   <div className={`bubble-row ${isMine ? 'mine' : 'other'}`}>
                     {/* unreadCount는 읽지 않은 사람 수이므로 0보다 클 때만 노출한다.
                         현재 UX 규칙은 말풍선이 아니라 텍스트 숫자만 메시지 앞에 붙이는 방식이다. */}
-                    {Number(msg.unreadCount) > 0 && (
+                    {!isMine && Number(msg.unreadCount) > 0 && (
                       <span className="message-unread-count">{msg.unreadCount > 99 ? '99+' : msg.unreadCount}</span>
                     )}
                     <p className="bubble">{msg.text}</p>
+                    {isMine && Number(msg.unreadCount) > 0 && (
+                      <span className="message-unread-count">{msg.unreadCount > 99 ? '99+' : msg.unreadCount}</span>
+                    )}
                   </div>
                   <p className="time">
                     {new Date(msg.timestamp).toLocaleTimeString([], {


### PR DESCRIPTION
## Summary
Place the current user's unread count on the outside-right of their message bubble while keeping incoming message layout unchanged.

## Changed Files
- src/features/chat/components/ChatPanel.jsx

## What’s Included
- Render unread count before the bubble for other users' messages.
- Render unread count after the bubble for the current user's messages.

## Impact
- Chat bubble unread count placement

## Validation
- npm run build

Closes #43