### PR TITLE
fix(chat): correct unread count side per sender

### DIFF
--- a/src/features/chat/components/ChatPanel.jsx
+++ b/src/features/chat/components/ChatPanel.jsx
@@ -71,11 +71,11 @@ function ChatPanel({
                   <div className={`bubble-row ${isMine ? 'mine' : 'other'}`}>
                     {/* unreadCount는 읽지 않은 사람 수이므로 0보다 클 때만 노출한다.
                         현재 UX 규칙은 말풍선이 아니라 텍스트 숫자만 메시지 앞에 붙이는 방식이다. */}
-                    {!isMine && Number(msg.unreadCount) > 0 && (
+                    {isMine && Number(msg.unreadCount) > 0 && (
                       <span className="message-unread-count">{msg.unreadCount > 99 ? '99+' : msg.unreadCount}</span>
                     )}
                     <p className="bubble">{msg.text}</p>
-                    {isMine && Number(msg.unreadCount) > 0 && (
+                    {!isMine && Number(msg.unreadCount) > 0 && (
                       <span className="message-unread-count">{msg.unreadCount > 99 ? '99+' : msg.unreadCount}</span>
                     )}
                   </div>


### PR DESCRIPTION
## Summary
Correct the unread-count placement so the current user's messages show unread count on the left and other users' messages show it on the right.

## Changed Files
- src/features/chat/components/ChatPanel.jsx

## What’s Included
- Render unread count before the bubble for the current user's messages.
- Render unread count after the bubble for other users' messages.
- Keep the rest of the chat bubble layout unchanged.

## Impact
- Chat bubble unread count placement

## Validation
- npm run build
