### PR TITLE
fix: avoid auto scroll on message metadata updates

### DIFF
--- a/src/features/chat/hooks/useChatMessages.js
+++ b/src/features/chat/hooks/useChatMessages.js
@@ -111,13 +111,13 @@ export const useChatMessages = ({ chatApi }) => {
   }, [chatApi, hasMoreHistory, historyCursor, isLoadingHistory, isLoadingOlderHistory])
 
   const appendMessage = useCallback((message) => {
-    setLastMessageMutation('append')
     setMessages((prev) => {
       // 서버 응답에 clientMessageId가 있으면 먼저 임시 메시지 교체 대상을 찾는다.
       // 같은 clientMessageId를 가진 optimistic 메시지가 있으면 실제 메시지로 덮어쓴다.
       if (message?.clientMessageId) {
         const optimisticIndex = prev.findIndex((item) => item?.clientMessageId === message.clientMessageId)
         if (optimisticIndex >= 0) {
+          setLastMessageMutation('update')
           const next = [...prev]
           next[optimisticIndex] = { ...next[optimisticIndex], ...message }
           return next
@@ -125,12 +125,14 @@ export const useChatMessages = ({ chatApi }) => {
       }
 
       if (message?.id && prev.some((item) => item?.id === message.id)) {
+        setLastMessageMutation('update')
         return prev.map((item) => {
           if (item?.id !== message.id) return item
           return { ...item, ...message }
         })
       }
 
+      setLastMessageMutation('append')
       return [...prev, message]
     })
   }, [])


### PR DESCRIPTION
Title
fix: avoid auto scroll on message metadata updates

Summary
기존 메시지의 unread/read 메타데이터 업데이트가 새 메시지 append로 오인되어 채팅 화면이 하단으로 튀는 문제를 수정했습니다.

Changed Files
- src/features/chat/hooks/useChatMessages.js

What’s Included
- 기존 메시지 교체/갱신은 `update`로 기록
- 실제 새 메시지 추가만 `append`로 기록
- 자동 하단 스크롤이 새 메시지 추가일 때만 동작하도록 보정

Impact
- 채팅 상세 화면의 스크롤 유지 동작
- unread/read 메타데이터 갱신 시 사용자 탐색 경험

Validation
- npm run build

Branch / Commit
- Branch: codex/issue-48-scroll-update
- Commit: 6031f64
- Push: origin/codex/issue-48-scroll-update