### PR TITLE
fix: improve light mode action visibility

### DIFF
--- a/.codex/worklogs/2026-03-11-issue-58-light-mode-contrast.md
+++ b/.codex/worklogs/2026-03-11-issue-58-light-mode-contrast.md
@@ -1,0 +1,38 @@
+# 2026-03-11 issue-58-light-mode-contrast
+
+## Timestamp
+- 2026-03-11 17:05
+
+## Task ID / Branch
+- issue: #58
+- branch: `codex/light-mode-cta-contrast`
+
+## Task
+- fixed light-mode contrast for CTA buttons in the friends header and chat participants menu
+
+## Context
+- the `+` action in the friends list and the invite action in the participants menu were hard to see in light mode
+- the current implementation used `bg-[var(--cta-bg)]` while `--cta-bg` is a gradient token, so the background could fall back poorly
+
+## Changes
+- added a shared `.cta-button` rule in `src/App.css`
+- moved the participants invite button and the floating create-room button to the shared CTA style
+- kept the small friends-header `+` button lighter and more icon-like by using stronger foreground contrast instead of a full CTA treatment
+- moved the participants invite button in `ParticipantsMenu.jsx` to the shared CTA class
+- split the participants menu actions into `Invite | Cancel` on the first row and a separate destructive `Leave` button on the next row
+- toned down the online status styling in the participants list to a quieter dot + pill treatment that matches the brand better
+- pushed the offline state further into the background so online/offline is easier to distinguish without increasing saturation
+
+## Docs
+- None
+
+## Validation
+- executed: `npm run build`
+- follow-up: visually confirm light/dark mode contrast on the friends screen and participants menu in the browser
+
+## Open risks
+- this change fixes the buttons covered by issue #58, but other gradient-backed buttons may still need the same treatment if they use the same pattern
+
+## Next
+- manually verify the two affected buttons in light and dark mode
+- if the visual result is good, commit and open a PR for issue #58

--- a/src/App.css
+++ b/src/App.css
@@ -279,6 +279,25 @@
   color: var(--brand-text);
 }
 
+.cta-button {
+  border-color: color-mix(in srgb, var(--brand-primary) 32%, var(--border-soft));
+  background-color: color-mix(in srgb, var(--brand-primary) 12%, var(--surface-elevated));
+  background-image: var(--cta-bg);
+  color: var(--cta-text);
+}
+
+.cta-button:hover {
+  filter: brightness(1.05);
+}
+
+.cta-button:disabled {
+  border-color: var(--border-soft);
+  background-color: var(--surface-muted);
+  background-image: none;
+  color: var(--text-secondary);
+  box-shadow: none;
+}
+
 .single-column-actions {
   grid-template-columns: 1fr;
 }

--- a/src/features/chat/components/ParticipantsMenu.jsx
+++ b/src/features/chat/components/ParticipantsMenu.jsx
@@ -51,7 +51,8 @@ function ParticipantsMenu({
                 return (
                   <li key={participant.userId} className="flex items-center justify-between gap-3 rounded-2xl border border-[var(--border-soft)] bg-[var(--surface-muted)] px-3 py-2 text-sm text-[var(--text-primary)]">
                     <span className="min-w-0 truncate">{participant.nickname}{isMe ? ' (나)' : ''}</span>
-                    <span className={`inline-flex items-center rounded-full border px-2.5 py-1 text-[11px] font-semibold ${participant.online ? 'border-brand-accent/30 bg-brand-accent/10 text-brand-accent' : 'border-[var(--border-soft)] bg-[var(--surface-elevated)] text-[var(--text-secondary)]'}`}>
+                    <span className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-semibold ${participant.online ? 'border-brand-primary/15 bg-brand-primary/8 text-[var(--text-primary)]' : 'border-[var(--border-soft)]/60 bg-[color-mix(in_srgb,var(--surface-elevated)_72%,transparent)] text-[color:color-mix(in_srgb,var(--text-secondary)_72%,transparent)]'}`}>
+                      <span className={`h-1.5 w-1.5 rounded-full ${participant.online ? 'bg-brand-primary/70' : 'bg-[color:color-mix(in_srgb,var(--text-tertiary)_55%,transparent)]'}`} />
                       {participant.online ? 'online' : 'offline'}
                     </span>
                   </li>
@@ -63,7 +64,7 @@ function ParticipantsMenu({
           <div className="mt-4 grid grid-cols-2 gap-2 border-t border-[var(--border-soft)] pt-3">
             <button
               type="button"
-              className="h-10 rounded-2xl border border-brand-primary/25 bg-[var(--cta-bg)] text-xs font-semibold text-[var(--cta-text)] shadow-[var(--shadow-glow)] transition hover:brightness-105 disabled:border-[var(--border-soft)] disabled:bg-[var(--surface-muted)] disabled:text-[var(--text-secondary)] disabled:shadow-none"
+              className="cta-button h-10 rounded-2xl border text-xs font-semibold shadow-[var(--shadow-glow)] transition"
               onClick={onOpenInvite}
               disabled={!joinedRoomId || !canInvite}
             >
@@ -71,7 +72,18 @@ function ParticipantsMenu({
             </button>
             <button
               type="button"
-              className="h-10 rounded-2xl border border-[var(--border-soft)] bg-[var(--surface-elevated)] text-xs font-semibold text-rose-300 transition hover:border-rose-300/40 hover:bg-rose-400/10 disabled:text-[var(--text-secondary)]"
+              className="h-10 rounded-2xl border border-[var(--border-soft)] bg-[var(--surface-elevated)] text-xs font-semibold text-[var(--text-primary)] transition hover:border-[var(--border-strong)] hover:bg-[var(--surface-muted)] disabled:text-[var(--text-secondary)]"
+              onClick={() => onToggle(false)}
+              disabled={!joinedRoomId}
+            >
+              취소
+            </button>
+          </div>
+
+          <div className="mt-2 border-t border-[var(--border-soft)] pt-3">
+            <button
+              type="button"
+              className="h-10 w-full rounded-2xl border border-[var(--border-soft)] bg-[var(--surface-elevated)] text-xs font-semibold text-rose-300 transition hover:border-rose-300/40 hover:bg-rose-400/10 disabled:text-[var(--text-secondary)]"
               onClick={onLeaveRoom}
               disabled={!joinedRoomId}
             >

--- a/src/features/chat/components/RoomPanel.jsx
+++ b/src/features/chat/components/RoomPanel.jsx
@@ -94,7 +94,7 @@ function RoomPanel({
         <div className="flex shrink-0 items-center gap-2">
           <button
             type="button"
-            className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-brand-primary/25 bg-[var(--cta-bg)] text-xl font-bold leading-none text-[var(--cta-text)] shadow-[var(--shadow-glow)] transition hover:brightness-105"
+            className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-brand-primary/20 bg-[var(--surface-elevated)] text-xl font-bold leading-none text-brand-primary shadow-[0_10px_22px_rgba(91,92,255,0.12)] transition hover:border-brand-primary/35 hover:bg-[color-mix(in_srgb,var(--brand-primary)_10%,var(--surface-elevated))] hover:text-brand-primary"
             aria-label="친구 추가"
             onClick={onOpenAddFriend}
           >
@@ -239,7 +239,7 @@ function RoomPanel({
 
       <button
         type="button"
-        className="absolute bottom-4 right-4 inline-flex h-14 w-14 items-center justify-center rounded-full border border-brand-primary/25 bg-[var(--cta-bg)] text-[30px] font-semibold leading-none text-[var(--cta-text)] shadow-[var(--shadow-glow)] transition hover:scale-[1.02] hover:brightness-105"
+        className="cta-button absolute bottom-4 right-4 inline-flex h-14 w-14 items-center justify-center rounded-full border text-[30px] font-semibold leading-none shadow-[var(--shadow-glow)] transition hover:scale-[1.02]"
         aria-label="새 채팅 만들기"
         onClick={onOpenCreateRoom}
       >


### PR DESCRIPTION
Title  
fix: improve light mode action visibility

Summary  
Improve light-mode visibility for the friends header add button and the participants menu actions. Keep the small header + more icon-like, keep invite as the main CTA, add an explicit cancel action to the participants menu, and tone down online/offline status styling so it feels more intentional.

Changed Files  
- .codex/worklogs/2026-03-11-issue-58-light-mode-contrast.md
- src/App.css
- src/features/chat/components/ParticipantsMenu.jsx
- src/features/chat/components/RoomPanel.jsx

What's Included  
- Add a shared CTA button treatment for gradient-backed actions
- Make the small friends-header + button lighter and more icon-like instead of a full CTA
- Keep the participants invite button as the primary CTA
- Change participants actions from Invite | Leave to Invite | Cancel plus a separate Leave row
- Tone down online status styling and push offline further into the background for clearer distinction
- Record the task in a dedicated worklog

Impact  
- Friends list header actions
- Participants dropdown actions
- Participants online/offline status styling
- Light/dark theme polish for issue #58

Validation  
- 
pm run build

Branch / Commit  
- Branch: codex/light-mode-cta-contrast  
- Commit: dd21d00  
- Push: origin/codex/light-mode-cta-contrast

PR  
- created via GitHub API