### PR TITLE
docs: require issue closing keywords in PRs

### DIFF
--- a/.codex/prompts/workflows/issue-to-pr.md
+++ b/.codex/prompts/workflows/issue-to-pr.md
@@ -94,6 +94,7 @@ Prepare:
 - validation
 - branch / commit status
 - PR or compare link status
+- issue closure line (`Closes #<issue-number>` when applicable)
 
 Only if the user explicitly asks:
 
@@ -101,6 +102,11 @@ Only if the user explicitly asks:
 2. commit
 3. push
 4. create PR
+
+If a PR is created for a tracked issue:
+
+1. include a closing keyword such as `Closes #123` in the PR body
+2. verify the issue number is correct before creating the PR
 
 ## Follow-up
 

--- a/.codex/worklogs/2026-03-11-issue-autoclose-guidance.md
+++ b/.codex/worklogs/2026-03-11-issue-autoclose-guidance.md
@@ -1,0 +1,36 @@
+# 2026-03-11 issue-autoclose-guidance
+
+## Timestamp
+- 2026-03-11 17:35
+
+## Task ID / Branch
+- branch: `codex/issue-autoclose-guidance`
+
+## Task
+- investigated why a merged PR did not auto-close its linked issue and added guidance to prevent the same mistake
+
+## Context
+- PR #60 was merged, but issue #58 remained open
+- the merged PR body did not include `Fixes #58` / `Closes #58` or any other GitHub closing keyword
+- current repository rules and issue-to-pr workflow did not explicitly require issue-closing keywords
+
+## Changes
+- added an AGENTS rule requiring a closing keyword in PR bodies when a PR is meant to resolve a tracked issue
+- added a CONTRIBUTING checklist item and summary section for issue closure
+- updated `.codex/prompts/workflows/issue-to-pr.md` to require an issue-closing line in PR delivery
+
+## Docs
+- `AGENTS.md`
+- `CONTRIBUTING.md`
+- `.codex/prompts/workflows/issue-to-pr.md`
+
+## Validation
+- executed: reviewed merged PR #60 body via GitHub API and confirmed the closing keyword was missing
+- follow-up: close issue #58 manually and use the new rule in the next issue-linked PR
+
+## Open risks
+- older open PRs may still be missing closing keywords and will need manual cleanup if they are merged as-is
+
+## Next
+- close issue #58 manually because the merged PR will not retroactively auto-close it on its own
+- include `Closes #...` in future issue-linked PR bodies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ Agents must review `docs/development-rules.md` before changing code, documentati
 2. Reports must include changed files, summary, validation, branch/commit, and PR or compare link.
 3. If something failed or was not applied, state that first and clearly.
 4. When a task changes code, docs, validation status, or release readiness, update a task-specific worklog under `.codex/worklogs/` in the same task.
+5. When a PR is intended to resolve a tracked GitHub Issue, include a closing keyword such as `Closes #123` in the PR body.
 
 ## 5. Validation Baseline
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,7 @@ This document defines the collaboration workflow for the Flownium Chat project.
 4. No unrelated files are mixed into the branch.
 5. Validation results are recorded in the PR summary.
 6. A task-specific worklog under `.codex/worklogs/` is added or updated when the task changed code, docs, validation status, or release readiness.
+7. If the PR resolves a GitHub Issue, include a closing keyword such as `Closes #123` in the PR body.
 
 ## 4. PR Summary Format
 
@@ -58,6 +59,9 @@ Branch / Commit
 
 PR  
 - <pull request url or compare url>
+
+Issue Closure  
+- <`Closes #123` or `None`>
 
 ## 5. Merge and Incident Rules
 


### PR DESCRIPTION
Title  
docs: require issue closing keywords in PRs

Summary  
Document why merged PRs may fail to close linked issues automatically and require GitHub closing keywords such as Closes #123 in future issue-linked PR bodies.

Changed Files  
- .codex/prompts/workflows/issue-to-pr.md
- .codex/worklogs/2026-03-11-issue-autoclose-guidance.md
- AGENTS.md
- CONTRIBUTING.md

What's Included  
- Add an AGENTS rule for issue-closing keywords in PR bodies
- Add a CONTRIBUTING checklist item and PR summary section for issue closure
- Update the issue-to-pr workflow to require an issue-closing line when applicable
- Record the root cause and follow-up in a dedicated worklog

Impact  
- PR authoring rules
- Issue-to-PR workflow consistency
- Less manual cleanup for merged issue-linked PRs

Validation  
- Reviewed merged PR #60 body via GitHub API and confirmed the missing closing keyword
- Manually closed issue #58 after documenting the reason

Branch / Commit  
- Branch: codex/issue-autoclose-guidance  
- Commit: ee301cd  
- Push: origin/codex/issue-autoclose-guidance

PR  
- created via GitHub API

Issue Closure  
- None