### PR TITLE
fix: resolve direct room names per user

### DIFF
--- a/.codex/worklogs/2026-03-12-fix-direct-room-display-name.md
+++ b/.codex/worklogs/2026-03-12-fix-direct-room-display-name.md
@@ -1,0 +1,22 @@
+# 2026-03-12 - Direct room display name
+
+## Summary
+
+- Fixed direct room naming so each user sees the counterpart nickname instead of a creator-side stored absolute room name.
+- Applied the same rule to both REST room responses and socket room payloads.
+
+## Files
+
+- `server/routes/chatroom.routes.cjs`
+- `server/index.cjs`
+- `docs/common/api-spec.md`
+
+## Validation
+
+- `node --check server/routes/chatroom.routes.cjs`
+- `node --check server/index.cjs`
+
+## Notes
+
+- Group room names still use the stored room name.
+- Direct room names are now derived at response time from the current user and the other member.

--- a/docs/common/api-spec.md
+++ b/docs/common/api-spec.md
@@ -514,6 +514,7 @@ MVP2-A 1차 표준:
 - 현재 사용자가 참여 중인 방 목록 조회
 - 정렬: `lastMessageAt desc` -> `createdAt desc`
 - 응답에 방별 `unreadCount`, 전체 `totalUnreadCount` 포함
+- direct 방의 `name`은 저장값이 아니라 현재 사용자 기준 상대 닉네임으로 내려온다
 - direct 방에 탈퇴 회원이 남아 있으면 `deletedMemberIds`, `hasDeletedMember`, `directChatDisabled`가 함께 내려온다
 
 응답 예시:

--- a/server/index.cjs
+++ b/server/index.cjs
@@ -77,13 +77,32 @@ const findDeletedMemberIds = async (memberIds) => {
   return deletedUsers.map((user) => String(user._id));
 };
 
-const toRoomResponse = async (roomDoc) => {
+const resolveDirectRoomName = async (roomDoc, currentUserId) => {
+  const memberIds = Array.isArray(roomDoc?.memberIds) ? roomDoc.memberIds.map((value) => String(value)) : [];
+  if (Boolean(roomDoc?.isGroup) || !currentUserId || memberIds.length !== 2) {
+    return String(roomDoc?.name || '').trim();
+  }
+
+  const counterpartUserId = memberIds.find((memberId) => memberId !== String(currentUserId));
+  if (!counterpartUserId) {
+    return String(roomDoc?.name || '').trim();
+  }
+
+  const counterpartUser = await User.findById(counterpartUserId)
+    .select({ nickname: 1 })
+    .lean();
+
+  return String(counterpartUser?.nickname || roomDoc?.name || '').trim();
+};
+
+const toRoomResponse = async (roomDoc, currentUserId = '') => {
   const memberIds = Array.isArray(roomDoc.memberIds) ? roomDoc.memberIds.map((value) => String(value)) : [];
   const deletedMemberIds = await findDeletedMemberIds(memberIds);
+  const resolvedName = await resolveDirectRoomName(roomDoc, currentUserId);
 
   return {
     id: String(roomDoc._id),
-    name: roomDoc.name,
+    name: resolvedName,
     isGroup: Boolean(roomDoc.isGroup),
     memberIds,
     lastMessage: roomDoc.lastMessage || '',
@@ -508,7 +527,7 @@ io.on('connection', (socket) => {
 
         socket.emit('room_joined', {
           roomId,
-          room: await toRoomResponse(room),
+          room: await toRoomResponse(room, socket.user.userId),
           participants,
         });
 

--- a/server/routes/chatroom.routes.cjs
+++ b/server/routes/chatroom.routes.cjs
@@ -67,13 +67,32 @@ const createChatroomRouter = ({
   };
 
   // 응답 형태를 한곳에서 고정해 두면 REST/소켓의 room 메타가 어긋나지 않는다.
-  const toRoomResponse = async (roomDoc, unreadCount = 0) => {
+  const resolveDirectRoomName = async (roomDoc, currentUserId) => {
+    const memberIds = Array.isArray(roomDoc?.memberIds) ? roomDoc.memberIds.map((value) => String(value)) : [];
+    if (Boolean(roomDoc?.isGroup) || !currentUserId || memberIds.length !== 2) {
+      return String(roomDoc?.name || '').trim();
+    }
+
+    const counterpartUserId = memberIds.find((memberId) => memberId !== String(currentUserId));
+    if (!counterpartUserId) {
+      return String(roomDoc?.name || '').trim();
+    }
+
+    const counterpartUser = await User.findById(counterpartUserId)
+      .select({ nickname: 1 })
+      .lean();
+
+    return String(counterpartUser?.nickname || roomDoc?.name || '').trim();
+  };
+
+  const toRoomResponse = async (roomDoc, currentUserId = '', unreadCount = 0) => {
     const memberIds = Array.isArray(roomDoc.memberIds) ? roomDoc.memberIds.map((value) => String(value)) : [];
     const deletedMemberIds = await findDeletedMemberIds(memberIds);
+    const resolvedName = await resolveDirectRoomName(roomDoc, currentUserId);
 
     return {
       id: String(roomDoc._id),
-      name: roomDoc.name,
+      name: resolvedName,
       isGroup: Boolean(roomDoc.isGroup),
       memberIds,
       lastMessage: roomDoc.lastMessage || '',
@@ -178,9 +197,11 @@ const createChatroomRouter = ({
     });
 
   const broadcastRoomUpdated = async (memberIds, roomDoc) => {
-    const roomPayload = await toRoomResponse(roomDoc);
     await Promise.all(
-      memberIds.map((memberId) => emitRoomUpdated?.(String(memberId), roomPayload))
+      memberIds.map(async (memberId) => {
+        const roomPayload = await toRoomResponse(roomDoc, String(memberId));
+        return emitRoomUpdated?.(String(memberId), roomPayload);
+      })
     );
   };
 
@@ -270,7 +291,7 @@ const createChatroomRouter = ({
         });
 
         await broadcastRoomUpdated([currentUserId], room);
-        res.status(201).json({ room: await toRoomResponse(room) });
+        res.status(201).json({ room: await toRoomResponse(room, currentUserId) });
         return;
       }
 
@@ -305,7 +326,7 @@ const createChatroomRouter = ({
         const friendUserId = normalizedTargetIds[0];
         const existingRoom = await findExistingDirectRoom(currentUserId, friendUserId);
         if (existingRoom) {
-          res.status(200).json({ room: await toRoomResponse(existingRoom), reused: true });
+          res.status(200).json({ room: await toRoomResponse(existingRoom, currentUserId), reused: true });
           return;
         }
 
@@ -326,7 +347,7 @@ const createChatroomRouter = ({
         });
 
         await broadcastRoomUpdated(room.memberIds, room);
-        res.status(201).json({ room: await toRoomResponse(room), reused: false });
+        res.status(201).json({ room: await toRoomResponse(room, currentUserId), reused: false });
         return;
       }
 
@@ -355,7 +376,7 @@ const createChatroomRouter = ({
       );
 
       await broadcastRoomUpdated(memberIds, room);
-      res.status(201).json({ room: await toRoomResponse(room) });
+      res.status(201).json({ room: await toRoomResponse(room, currentUserId) });
     } catch (error) {
       sendError(res, 500, 'CHATROOM_CREATE_FAILED', error.message || 'failed to create chatroom');
     }
@@ -467,7 +488,7 @@ const createChatroomRouter = ({
         await emitRoomParticipants?.(String(room._id));
 
         res.status(200).json({
-          room: await toRoomResponse(room),
+          room: await toRoomResponse(room, currentUserId),
           createdNewRoom: false,
         });
         return;
@@ -506,7 +527,7 @@ const createChatroomRouter = ({
 
       await broadcastRoomUpdated(nextMemberIds, nextRoom);
       res.status(201).json({
-        room: await toRoomResponse(nextRoom),
+        room: await toRoomResponse(nextRoom, currentUserId),
         createdNewRoom: true,
       });
     } catch (error) {
@@ -587,7 +608,7 @@ const createChatroomRouter = ({
       await emitRoomParticipants?.(roomId);
 
       res.status(200).json({
-        room: await toRoomResponse(room),
+        room: await toRoomResponse(room, currentUserId),
         deleted: false,
       });
     } catch (error) {
@@ -617,7 +638,7 @@ const createChatroomRouter = ({
           const currentRoomId = String(room._id);
           const readState = readStateByRoomId.get(currentRoomId);
           const unreadCount = await getUnreadCountForRoom(currentRoomId, req.user.userId, readState?.lastReadAt || null);
-          return await toRoomResponse(room, unreadCount);
+          return await toRoomResponse(room, req.user.userId, unreadCount);
         })
       );
 


### PR DESCRIPTION
﻿Title
fix: resolve direct room names per user

Summary
Ensure direct room names are resolved per viewer so each user sees the counterpart nickname instead of a fixed room name saved from the creator side.

Changed Files
- .codex/worklogs/2026-03-12-fix-direct-room-display-name.md
- docs/common/api-spec.md
- server/index.cjs
- server/routes/chatroom.routes.cjs

What’s Included
- Changed direct room response shaping to compute the display name from the current user’s counterpart.
- Applied the same direct-room naming rule to REST room responses and socket-driven room updates.
- Updated the API spec to document that direct room names are returned per current user.
- Added a task worklog for the direct-room display-name fix.

Impact
- Chat room list UI now shows the other participant’s nickname consistently in 1:1 rooms.
- Socket room update/join flows now align with REST naming behavior.
- No group-room naming behavior was changed.

Validation
- `node --check server/routes/chatroom.routes.cjs`
- `node --check server/index.cjs`

Branch / Commit
- Branch: codex/email-auth-phase1
- Commit: ae03ef2
- Push: origin/codex/email-auth-phase1

PR
- https://github.com/yoooon0104/flownium-chat-2.0/pull/68

Issue Closure
- None
