### PR TITLE
fix: adjust friend email fallback copy

### DIFF
--- a/.codex/worklogs/2026-03-12-review-fix-friend-email-fallback.md
+++ b/.codex/worklogs/2026-03-12-review-fix-friend-email-fallback.md
@@ -1,0 +1,17 @@
+# 2026-03-12 Review Fix - Friend Action Sheet Email Fallback
+
+## Target Finding
+
+- Mobile friend action sheet still rendered `이메일 미등록`, which treats a missing email as a normal state even though current signup policy requires email.
+
+## Root Cause
+
+- The fallback copy in `FriendActionSheet` was not updated when settings screens were changed to treat missing email as an abnormal state.
+
+## Fix
+
+- Replaced the fallback label with `이메일 정보를 불러오지 못했습니다.` for non-deleted friends.
+
+## Validation
+
+- `npm run build`

--- a/src/features/friends/components/FriendActionSheet.jsx
+++ b/src/features/friends/components/FriendActionSheet.jsx
@@ -35,7 +35,7 @@ function FriendActionSheet({ friend, isOpen, onStartChat, onClose }) {
           </span>
           <div>
             <h3>{friend.nickname || '이름 없음'}{friend.isDeleted ? ' (탈퇴한 회원)' : ''}</h3>
-            <p>{friend.isDeleted ? '프로필을 볼 수 없습니다.' : (friend.email || '이메일 미등록')}</p>
+            <p>{friend.isDeleted ? '프로필을 볼 수 없습니다.' : (friend.email || '이메일 정보를 불러오지 못했습니다.')}</p>
           </div>
         </div>
         <div className="modal-actions single-column-actions">


### PR DESCRIPTION
﻿Title
fix: adjust friend email fallback copy

Summary
Fix the mobile friend action sheet so a missing email is treated as an abnormal state, not as a normal unregistered state, in line with the current required-email signup policy.

Changed Files
- .codex/worklogs/2026-03-12-review-fix-friend-email-fallback.md
- src/features/friends/components/FriendActionSheet.jsx

What’s Included
- Replaced the mobile friend action sheet fallback copy from `이메일 미등록` to `이메일 정보를 불러오지 못했습니다.`.
- Added a task worklog for the review-to-fix change.

Impact
- Mobile friend action sheet copy now aligns with the current email-required account policy.
- No API, data, or interaction flow was changed.

Validation
- `npm run build`

Branch / Commit
- Branch: fix/friend-email-fallback-copy
- Commit: 4d7a462
- Push: origin/fix/friend-email-fallback-copy

PR
- pending

Issue Closure
- Closes #71
