### PR TITLE
fix: sync room list updates and unify scrollbars

### DIFF
--- a/.codex/worklogs/2026-03-12-fix-room-sync-and-scrollbars.md
+++ b/.codex/worklogs/2026-03-12-fix-room-sync-and-scrollbars.md
@@ -1,0 +1,22 @@
+# 2026-03-12 - Fix room sync and scrollbar styling
+
+## Summary
+
+- fixed room list realtime sync so incoming messages also trigger `room_updated`
+- aligned scrollbar styling with the current Flownium UI using global theme-aware tokens
+
+## Changed Files
+
+- `server/index.cjs`
+- `src/index.css`
+- `docs/common/socket-events.md`
+
+## Validation
+
+- `node --check server/index.cjs`
+- `npm run build`
+
+## Notes
+
+- current room messages still append immediately through `receive_message`
+- room list refresh now follows `room_updated` for both active and inactive rooms

--- a/docs/common/socket-events.md
+++ b/docs/common/socket-events.md
@@ -37,6 +37,7 @@
 - direct 방에 탈퇴 회원이 남아 있으면 전송을 막고 `DELETED_MEMBER` 에러를 반환
 - 방의 `lastMessage`, `lastMessageAt` 갱신
 - `receive_message` 브로드캐스트
+- `room_updated`를 사용자 전용 room으로 같이 전송해 방 목록 메타를 즉시 갱신
 - ack 응답으로 전송 성공/실패를 호출자에게 즉시 반환
 
 ack 성공:
@@ -111,7 +112,7 @@ ack 실패:
 
 규칙:
 - 사용자 전용 room(`user:<userId>`)으로 전달
-- 새 방 생성, 초대, 나가기 후 방 메타가 바뀌면 전송
+- 새 방 생성, 초대, 나가기, 새 메시지 저장 후 방 메타가 바뀌면 전송
 - 프론트는 이 이벤트를 받으면 방 목록을 다시 조회해 room 메타와 unread를 맞춘다
 
 ### room_deleted

--- a/server/index.cjs
+++ b/server/index.cjs
@@ -197,6 +197,16 @@ const emitRoomDeleted = (userId, roomId) => {
   });
 };
 
+const broadcastRoomUpdated = async (roomDoc) => {
+  const memberIds = Array.isArray(roomDoc?.memberIds) ? roomDoc.memberIds.map((value) => String(value)) : [];
+  await Promise.all(
+    memberIds.map(async (memberId) => {
+      const roomPayload = await toRoomResponse(roomDoc, memberId);
+      emitRoomUpdated(memberId, roomPayload);
+    })
+  );
+};
+
 const addPresence = (roomId, userId, socketId) => {
   if (!roomPresence.has(roomId)) {
     roomPresence.set(roomId, new Map());
@@ -618,6 +628,7 @@ io.on('connection', (socket) => {
       room.lastMessageAt = message.timestamp;
       await room.save();
 
+      await broadcastRoomUpdated(room);
       await emitRoomMessage(room, message, clientMessageId || null);
 
       reply({

--- a/src/index.css
+++ b/src/index.css
@@ -41,6 +41,9 @@
   --bubble-other-text: #111827;
   --system-pill-bg: rgba(91, 92, 255, 0.08);
   --system-pill-text: #5f6b7a;
+  --scrollbar-thumb: rgba(106, 116, 140, 0.26);
+  --scrollbar-thumb-hover: rgba(91, 92, 255, 0.34);
+  --scrollbar-track: transparent;
 }
 
 :root[data-resolved-theme='dark'] {
@@ -75,6 +78,9 @@
   --bubble-other-text: #f5f7ff;
   --system-pill-bg: rgba(255, 255, 255, 0.06);
   --system-pill-text: #9aa3b2;
+  --scrollbar-thumb: rgba(154, 163, 178, 0.18);
+  --scrollbar-thumb-hover: rgba(154, 163, 178, 0.3);
+  --scrollbar-track: transparent;
 }
 
 /* 전체 레이아웃 계산을 단순화하기 위한 기본 박스모델 */
@@ -100,6 +106,32 @@ body {
 button,
 input {
   font: inherit;
+}
+
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+}
+
+*::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+*::-webkit-scrollbar-track {
+  background: var(--scrollbar-track);
+}
+
+*::-webkit-scrollbar-thumb {
+  border: 3px solid transparent;
+  border-radius: 999px;
+  background: var(--scrollbar-thumb);
+  background-clip: padding-box;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background: var(--scrollbar-thumb-hover);
+  background-clip: padding-box;
 }
 
 body {


### PR DESCRIPTION
﻿Title
fix: sync room list updates and unify scrollbars

Summary
Room list metadata was not refreshing consistently in realtime when new messages arrived, especially when the currently open room received a message. This change broadcasts `room_updated` on message send so the room list refresh path stays active, and it aligns scrollbar styling with the current Flownium UI across scrollable surfaces.

Changed Files
- .codex/worklogs/2026-03-12-fix-room-sync-and-scrollbars.md
- docs/common/socket-events.md
- server/index.cjs
- src/index.css

What’s Included
- Broadcast `room_updated` to room members whenever a new message is persisted
- Keep existing `receive_message` behavior for chat body append intact
- Add theme-aware global scrollbar tokens and subtle scrollbar styling for scrollable surfaces
- Update socket event documentation and add a task worklog

Impact
- Chat room list realtime sync
- Room ordering and last-message metadata refresh
- Global scrollbar styling across the UI

Validation
- node --check server/index.cjs
- npm run build

Branch / Commit
- Branch: fix/room-sync-and-scrollbars
- Commit: 9b9edca
- Push: origin/fix/room-sync-and-scrollbars

PR
- pending

Issue Closure
- Closes #76
