### PR TITLE
docs: refresh project overview and auth docs

### DIFF
--- a/.codex/worklogs/2026-03-12-docs-project-overview-refresh.md
+++ b/.codex/worklogs/2026-03-12-docs-project-overview-refresh.md
@@ -1,0 +1,18 @@
+# 2026-03-12 - Project documentation refresh
+
+## Summary
+
+- refreshed high-level project documents to match the current auth, account, branding, and chat state
+- rewrote broken or outdated overview/readme documents in UTF-8
+- aligned authentication flow documentation with email auth, password reset, kakao link/unlink, and tombstone rules
+
+## Changed Files
+
+- `README.md`
+- `docs/README.md`
+- `docs/common/project-overview.md`
+- `docs/common/auth-flow.md`
+
+## Validation
+
+- manual re-read of rewritten files

--- a/README.md
+++ b/README.md
@@ -1,56 +1,34 @@
 # Flownium Chat 2.0
 
 <p align="left">
-  <img src="assets/branding/logo/flownium-wordmark-light.png" alt="Flownium" width="260" />
+  <img src="assets/branding/logo/flownium-logo_wordmark-on-dark.png" alt="Flownium" width="260" />
 </p>
 
-Flownium Chat 2.0은 **카카오 로그인 기반의 실시간 친구/그룹 채팅 서비스**입니다.  
-처음 보는 사람도 바로 이해할 수 있도록 요약하면,
+Flownium Chat 2.0는 친구 기반 1:1/그룹 채팅을 중심으로, 이메일 로그인과 카카오 간편로그인을 함께 지원하는 실시간 채팅 서비스입니다.
 
-- 카카오 계정으로 로그인하고
-- 친구를 추가하거나 채팅방을 만들고
-- 실시간으로 대화를 주고받는 앱입니다.
-
-## Flownium이란?
-
-Flownium은 "대화 흐름(flow)을 끊지 않는 팀 커뮤니케이션"을 목표로 합니다.
-현재 버전은 **MVP2-B 1차 구현**까지 반영되어 있으며,
-친구 기반 1:1/그룹 채팅, 알림 허브, unread 표시까지 포함합니다.
+현재 기준 주요 기능:
+- 친구 검색/요청/수락/거절/차단
+- 친구 기반 1:1 채팅방 재사용, 그룹 채팅방 생성
+- 실시간 메시지 송수신, unread 표시, 이전 메시지 커서 로드
+- 알림 허브(데스크톱 드롭다운 / 모바일 전용 화면)
+- 이메일 회원가입, 이메일 로그인, 비밀번호 재설정
+- 카카오 간편로그인, 카카오 계정 연결/해제
+- 내 정보 / 설정 분리 구조
+- 회원탈퇴 tombstone 처리
 
 ## 현재 상태
 
-- 로컬/운영 환경 카카오 로그인 1차 검증 완료
-- Vercel/Render/Atlas 배포 경로 확정
 - MVP2-B 1차 구현 완료
-- 실제 친구 계정 기준 E2E 일부만 남아 있음
-
-## 현재 제공 기능 (지금 기준)
-
-- 카카오 OAuth 로그인 + 온보딩 분기
-- JWT Access/Refresh 인증
-- Friends/Rooms 탭 UI
-- 친구 검색/요청/수락/거절/차단
-- 친구 기반 1:1 방 재사용 / 그룹방 생성
-- 그룹 채팅방 생성/목록/입장
-- 실시간 메시지 송수신 (Socket.IO)
-- 메시지 히스토리 조회
-- 친구 요청/방 초대 알림 허브
-- 모바일 알림 전용 화면
-- 모바일 하단 탭바
-- 참여자 목록 + online/offline 상태 표시
-- 방 검색 + FAB(+) 생성 UX
-- 방 목록 unread count / 메시지 unread 숫자 표시
-- 사용자 메뉴(내 정보/설정/로그아웃)
-- 표준 에러 응답(`error.code`, `error.message`)
-- 로그인 상태 확인 API(`/auth/me`)
-- 운영 배포 기준 카카오 로그인 성공
+- 이메일 인증/비밀번호 재설정/카카오 연결 흐름 1차 구현 완료
+- 브랜딩/아이콘/로그인 화면 1차 반영 완료
+- 실제 다계정 E2E 검증은 추가 진행 필요
 
 ## 기술 스택
 
-- Frontend: React, Vite
+- Frontend: React, Vite, Tailwind CSS
 - Backend: Express, Socket.IO
 - Database: MongoDB (Mongoose)
-- Auth: Kakao OAuth + JWT
+- Auth: JWT + Kakao OAuth + Email AuthIdentity
 - Deploy: Vercel, Render, MongoDB Atlas
 
 ## 프로젝트 구조
@@ -58,10 +36,10 @@ Flownium은 "대화 흐름(flow)을 끊지 않는 팀 커뮤니케이션"을 목
 ```txt
 flownium-chat-2.0/
   src/
-    app/                # AppShell(조립)
-    features/           # auth/chat/user 기능 단위
-    domain/             # 순수 규칙 객체
-    services/           # API/Socket I/O
+    app/                # AppShell 조립
+    features/           # auth/chat/friends/user 등 기능 단위
+    domain/             # 사용자/세션 정규화 규칙
+    services/           # REST / Socket I/O
   server/
     models/
     routes/
@@ -70,15 +48,13 @@ flownium-chat-2.0/
   docs/
 ```
 
-## 환경변수
+## 환경 변수
 
 ### 프론트 (`.env`)
 
 ```env
 VITE_KAKAO_CLIENT_ID=
-# Redirect URI는 끝 슬래시 없이 통일 권장
 VITE_KAKAO_REDIRECT_URI=http://localhost:5173
-# 미설정 시 http://localhost:3010 fallback
 VITE_API_BASE_URL=http://localhost:3010
 ```
 
@@ -102,30 +78,33 @@ KAKAO_CLIENT_SECRET=
 ```
 
 주의:
-- 현재 구현에서 프론트 `VITE_KAKAO_CLIENT_ID`는 카카오 인가 URL의 `client_id`로 사용되며, 코드 기준 `REST API 키`를 사용한다.
-- `VITE_KAKAO_REDIRECT_URI`, `KAKAO_REDIRECT_URI`, 카카오 콘솔 Redirect URI는 동일 문자열이어야 한다.
-- 기본 정책은 끝 슬래시 없는 URI로 통일한다.
+- `VITE_KAKAO_REDIRECT_URI`, `KAKAO_REDIRECT_URI`, 카카오 콘솔 Redirect URI는 완전히 같은 문자열이어야 합니다.
+- 기본 정책은 끝 슬래시 없는 URI를 사용합니다.
 
 ## 로컬 실행
 
 1. 루트 의존성 설치
+
 ```bash
 npm install
 ```
 
 2. 서버 의존성 설치
+
 ```bash
 cd server
 npm install
 ```
 
 3. 서버 실행
+
 ```bash
 cd server
 npm run dev
 ```
 
-4. 프론트 실행 (새 터미널)
+4. 프론트 실행
+
 ```bash
 npm run dev
 ```
@@ -134,23 +113,22 @@ npm run dev
 - 프론트: `http://localhost:5173`
 - 서버 헬스체크: `http://localhost:3010/api/health`
 
-## 검증 스크립트
+## 기본 검증
 
-- 에러 표준 검증: `scripts/test-error-code.ps1`
-- 인증 상태 검증(`/auth/me`): `scripts/test-auth-me.ps1`
-- 배포 전 빠른 통합 검증: `scripts/test-prod-ready.ps1`
+- 프론트: `npm run build`
+- 서버 라우트/모델: `node --check <file>`
 
 ## 문서 바로가기
 
 - [문서 인덱스](docs/README.md)
 - [프로젝트 개요](docs/common/project-overview.md)
 - [아키텍처](docs/common/architecture.md)
+- [인증 흐름](docs/common/auth-flow.md)
 - [API 명세](docs/common/api-spec.md)
 - [소켓 이벤트](docs/common/socket-events.md)
-- [인증 흐름](docs/common/auth-flow.md)
-- [UI 계획](docs/common/ui-plan.md)
+- [화면 정의](docs/planning/screen-spec.md)
+- [오브젝트 정의](docs/planning/object-spec.md)
 - [WBS](docs/common/wbs.md)
 - [배포 런북](docs/operations/deploy-runbook.md)
-- [운영 로그 기준](docs/operations/ops-log-policy.md)
 - [개발 규칙](docs/development-rules.md)
 - [기여 가이드](CONTRIBUTING.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,46 +1,48 @@
 # 문서 인덱스
 
-업데이트: 2026-03-10
+업데이트: 2026-03-12
 
-## 문서 구조 원칙
+## 문서 구조
 
-- `docs/common`: 현재 운영 기준 문서 (항상 최신)
-- `docs/planning`: 다음 단계 정의서/초안
-- `docs/operations`: 배포/장애/운영 기준
-- `docs/releases`: 차수별 확정 스냅샷
-- `docs/flows`: 기능 플로우차트
-- `docs/decisions`: ADR(의사결정 기록)
-- `docs/qa`: 테스트/검증 문서
-- `docs/security`: 보안/개인정보 정책
+- `docs/common`
+  - 현재 구현 기준의 운영 문서
+- `docs/planning`
+  - 화면/오브젝트/요구사항 정의
+- `docs/operations`
+  - 배포, 운영, 검증, 작업 로그 정책
+- `docs/decisions`
+  - ADR 및 의사결정 기록
+- `docs/flows`
+  - 기능 흐름 관련 문서
+- `docs/qa`
+  - 검증/테스트 관련 문서
+- `docs/security`
+  - 보안/개인정보 관련 문서
 
-## 가장 먼저 볼 문서
+## 먼저 볼 문서
 
 1. `docs/common/project-overview.md`
-2. `docs/common/wbs.md`
-3. `docs/common/ui-plan.md`
-4. `docs/common/api-spec.md`
-5. `docs/common/socket-events.md`
-6. `docs/operations/deploy-runbook.md`
-7. `docs/operations/realtime-validation-checklist.md`
-8. `docs/common/env-policy.md`
-9. `docs/operations/new-machine-setup.md`
+2. `docs/common/architecture.md`
+3. `docs/common/wbs.md`
+4. `docs/common/auth-flow.md`
+5. `docs/common/api-spec.md`
+6. `docs/common/socket-events.md`
+7. `docs/planning/screen-spec.md`
+8. `docs/planning/object-spec.md`
+9. `docs/operations/deploy-runbook.md`
+10. `docs/development-rules.md`
 
 ## common
 
 - `project-overview.md`
 - `architecture.md`
+- `auth-flow.md`
 - `api-spec.md`
 - `socket-events.md`
 - `database-design.md`
-- `auth-flow.md`
 - `ui-plan.md`
 - `wbs.md`
 - `env-policy.md`
-
-## root-level guides
-
-- `docs/development-rules.md`
-- `CONTRIBUTING.md`
 
 ## planning
 
@@ -55,10 +57,15 @@
 - `new-machine-setup.md`
 - `ops-log-policy.md`
 - `realtime-validation-checklist.md`
+- `worklog.md`
+
+## root-level guides
+
+- `docs/development-rules.md`
+- `CONTRIBUTING.md`
 
 ## branding assets
 
 - 가이드: `assets/branding/usage-guide.md`
-- 로고: `assets/branding/logo/`
-- 아이콘: `assets/branding/icons/`
-- 컬러 팔레트: `assets/branding/color-palette/`
+- 로고 소스: `assets/branding/logo/`
+- 배포용 아이콘: `public/branding/`

--- a/docs/common/auth-flow.md
+++ b/docs/common/auth-flow.md
@@ -1,77 +1,140 @@
-﻿# 인증 흐름
+# 인증 흐름
 
-업데이트: 2026-03-09
+업데이트: 2026-03-12
 
-## 1) 카카오 로그인 + 온보딩 분기
+## 1) 카카오 간편로그인
 
-1. 로그인 게이트에서 `카카오로 시작하기` 클릭
-2. 프론트는 `VITE_KAKAO_CLIENT_ID`와 `VITE_KAKAO_REDIRECT_URI`로 카카오 인가 URL을 생성한다.
-3. 카카오 인증 후 `code`가 `VITE_KAKAO_REDIRECT_URI`로 전달된다.
+1. 로그인 화면에서 `카카오로 시작하기` 클릭
+2. 프론트가 카카오 인가 URL로 이동
+3. 카카오 인증 후 `code`가 redirect URI로 돌아옴
 4. 프론트가 `GET /auth/kakao/callback?code=` 호출
-5. 서버 응답 분기:
-- `LOGIN_SUCCESS`: 토큰 저장 후 채팅 화면 진입
-- `SIGNUP_REQUIRED`: 온보딩 화면으로 이동
+5. 서버가 `AuthIdentity(provider='kakao')` 기준으로 사용자 식별
+
+응답 분기:
+- `LOGIN_SUCCESS`
+  - 기존 active 사용자 로그인
+- `SIGNUP_REQUIRED`
+  - 최초 사용자 가입 필요
+- `LINK_SUCCESS`
+  - 현재 로그인한 이메일 회원 계정에 카카오 연결 완료
 
 참고:
-- 카카오 프로필에서 `email`, `nickname`, `profileImage`를 수집한다.
-- 이메일은 동의 범위에 따라 빈 문자열일 수 있다.
-- 현재 구현에서 프론트 `client_id`는 카카오 인가 URL 생성용으로 사용되며, 코드 기준 `REST API 키`를 사용한다.
+- 카카오 매핑 기준은 이메일이 아니라 카카오 고유 사용자 ID
+- 카카오 이메일은 가입 완료 필수값이 아니라 참고 정보
 
-## 2) 운영 Redirect URI 규칙
+## 2) 카카오 최초 가입(온보딩) 흐름
 
-1. 프론트 `VITE_KAKAO_REDIRECT_URI`
-2. 서버 `KAKAO_REDIRECT_URI`
-3. 카카오 콘솔 Redirect URI
+1. `SIGNUP_REQUIRED` 응답 수신
+2. 온보딩 화면에서 닉네임 입력
+3. 약관 동의
+4. `POST /auth/signup/complete`
+5. 성공 시 토큰 저장 + 메인 화면 진입
 
-위 세 값은 **완전히 동일한 문자열**이어야 한다.
-기본 운영 정책은 끝 슬래시 없는 URI(`https://flownium-chat-2-0.vercel.app`)로 통일한다.
+정책:
+- tombstone 계정은 복구하지 않음
+- 필요한 경우 새 `User` 생성
 
-## 3) 온보딩(최초 가입) 흐름
+## 3) 이메일 회원가입 흐름
 
-1. 온보딩 화면에서 닉네임(2~20자) 입력
-2. 가입 동의 체크(`agreedToTerms=true`)
-3. `POST /auth/signup/complete` 호출
-4. 성공 시 토큰 저장 + 채팅 화면 진입
+1. 로그인 화면에서 `회원가입` 진입
+2. 입력:
+   - 이메일
+   - 닉네임
+   - 비밀번호
+   - 비밀번호 확인
+   - 약관 동의
+3. `POST /auth/email/signup/start`
+4. 서버가 `EmailVerification` pending record 생성
+5. 개발 단계에서는 `debugCode` 또는 서버 로그로 인증 코드 확인
+6. `POST /auth/email/signup/verify`
+7. 성공 시 `User + AuthIdentity(email)` 생성
+8. 즉시 로그인 성공 후 메인 화면 진입
 
-## 4) 앱 초기 진입(세션 복원) 흐름
+정책:
+- 인증 전에는 `User`를 만들지 않음
+- active 동일 이메일 계정이 있으면 회원가입 시작 차단
+- 이메일 회원가입과 카카오 계정은 자동 병합하지 않음
+
+## 4) 이메일 로그인 흐름
+
+1. 로그인 화면에서 이메일/비밀번호 입력
+2. `POST /auth/email/login`
+3. verified email identity 기준 로그인
+4. 성공 시 토큰 저장 + 메인 화면 진입
+
+대표 실패 분기:
+- 미가입 이메일
+- 미인증 이메일
+- 비밀번호 불일치
+- 사용 불가 계정
+
+## 5) 비밀번호 재설정 흐름
+
+1. 로그인 화면에서 `비밀번호 재설정` 진입
+2. 이메일 + 새 비밀번호 입력
+3. `POST /auth/email/password-reset/start`
+4. 서버가 `PasswordResetVerification` pending record 생성
+5. 개발 단계에서는 `debugCode` 또는 서버 로그로 코드 확인
+6. `POST /auth/email/password-reset/verify`
+7. 성공 시 `AuthIdentity(email).secretHash` 교체
+8. 기존 refresh token 무효화
+9. 로그인 화면으로 복귀 후 새 비밀번호로 로그인
+
+## 6) 카카오 계정 연결 흐름
+
+1. 이메일 회원이 로그인
+2. `내 정보` 화면에서 `카카오 계정 연결`
+3. `POST /auth/kakao/link/start`
+4. 프론트가 authorize URL로 이동
+5. 카카오 인증 후 callback 복귀
+6. callback에 `state`가 있으면 로그인 대신 연결 처리
+7. `LINK_SUCCESS` 응답 후 현재 계정에 `linkedProviders` 갱신
+
+정책:
+- 자동 병합 없음
+- 이미 다른 사용자에 연결된 카카오 계정은 연결 불가
+
+## 7) 카카오 계정 연결 해제 흐름
+
+1. `내 정보` 화면에서 `카카오 연결 해제`
+2. `DELETE /auth/kakao/link`
+3. 서버가 현재 사용자에 연결된 kakao identity를 제거
+
+정책:
+- 연결된 카카오가 없으면 실패
+- 마지막 로그인 수단 하나만 남은 계정은 해제 불가
+- 해제 후 `linkedProviders` 갱신
+
+## 8) 앱 초기 진입(세션 복원)
 
 1. 저장된 access token 존재 여부 확인
-2. 토큰이 있으면 `GET /auth/me` 호출
-3. 성공 시 사용자 상태 복원 후 채팅 화면 진입
-4. 401이면 `POST /auth/refresh` 재시도 후 `/auth/me` 재호출
-5. 재시도 실패 시 세션 정리 + 로그인 게이트 복귀
+2. 있으면 `GET /auth/me`
+3. 401이면 `POST /auth/refresh` 1회 시도
+4. refresh 성공 시 `/auth/me` 재호출
+5. 실패 시 세션 정리 후 로그인 화면 복귀
 
-## 5) 토큰 재발급 흐름
-
-1. 인증 REST 요청에서 401 발생
-2. `POST /auth/refresh` 1회 시도
-3. 성공 시 토큰 갱신 후 원요청 재시도
-4. 실패 시 세션 정리 후 로그인 게이트로 복귀
-
-## 6) 소켓 인증 흐름
+## 9) 소켓 인증 흐름
 
 - Socket.IO 연결 시 `auth.token`으로 access token 전달
 - 서버 `io.use`에서 JWT 검증
 - `unauthorized` 발생 시 refresh 후 재연결 시도
 - 재연결 실패 시 세션 종료
 
-## 7) 카카오 콜백 중복 처리 방어
+## 10) 회원탈퇴 흐름
 
-- 카카오 인가 코드는 1회용이다.
-- 프론트는 callback URL의 `code`를 읽은 직후 주소창 query를 제거한다.
-- 동일 `code`는 `sessionStorage` 기준으로 중복 처리하지 않는다.
-- 새로고침/재렌더로 같은 `code`를 다시 보내면 로그인 재시도를 유도한다.
+1. `DELETE /auth/account`
+2. 사용자 문서는 tombstone 상태로 전환
+3. 연결된 로그인 수단 제거
+4. 친구/알림/읽음 상태 정리
+5. direct/group 방 정책에 따라 채팅 문맥 정리
+6. 클라이언트 세션 삭제 후 로그인 화면 복귀
 
-## 8) 로그아웃 흐름
+## 11) Redirect URI 규칙
 
-- 로컬 토큰 삭제
-- 소켓 연결 정리(disconnect)
-- 방/메시지/모달 상태 초기화
-- 로그인 게이트로 복귀
+아래 세 값은 완전히 동일한 문자열이어야 합니다.
 
-## 9) 카카오 로그인 실패 시 확인 포인트
+1. 프론트 `VITE_KAKAO_REDIRECT_URI`
+2. 서버 `KAKAO_REDIRECT_URI`
+3. 카카오 콘솔 Redirect URI
 
-1. `VITE_KAKAO_REDIRECT_URI`, `KAKAO_REDIRECT_URI`, 카카오 콘솔 Redirect URI가 완전히 같은지 확인
-2. Vercel/Render 환경변수 변경 후 각각 재배포했는지 확인
-3. `KOE006`는 redirect URI 불일치 가능성이 높다.
-4. `KOE320`는 인가 코드 재사용 또는 client/server redirect URI 불일치 가능성이 높다.
+기본 정책은 끝 슬래시 없는 URI를 사용합니다.

--- a/docs/common/project-overview.md
+++ b/docs/common/project-overview.md
@@ -1,62 +1,77 @@
-﻿# 프로젝트 개요
+# 프로젝트 개요
 
-업데이트: 2026-03-10
+업데이트: 2026-03-12
 
 ## 1) Flownium Chat이 무엇인가?
 
-Flownium Chat은 **카카오 로그인 기반 실시간 친구/그룹 채팅 서비스**입니다.
-핵심 목표는 "로그인부터 메시지 송수신까지 끊기지 않는 대화 흐름"입니다.
+Flownium Chat은 친구 기반 1:1/그룹 채팅을 중심으로, 이메일 인증과 카카오 간편로그인을 함께 지원하는 실시간 채팅 서비스입니다.
 
-현재 상태:
-- MVP1 핵심 기능 완료
-- MVP2-A 운영 로그인/배포 검증 1차 완료
-- MVP2-B 1차 구현 완료
-- 실제 친구 계정 기준 검증 진행 전
+핵심 목표:
+- 로그인부터 대화 시작까지 끊기지 않는 흐름 제공
+- 친구 관계 기반의 안전한 채팅 경험 제공
+- 향후 익명방/비회원 확장까지 고려한 계정 구조 유지
 
 ## 2) 현재 제공 기능
 
-- 카카오 로그인 + 온보딩 분기(`LOGIN_SUCCESS` / `SIGNUP_REQUIRED`)
-- JWT Access/Refresh 인증
+- 카카오 간편로그인 + 온보딩 분기(`LOGIN_SUCCESS`, `SIGNUP_REQUIRED`)
+- 이메일 회원가입 + 이메일 인증 + 이메일 로그인
+- 이메일 비밀번호 재설정
+- JWT Access / Refresh 인증
 - 로그인 상태 확인 API(`GET /auth/me`)
-- Friends/Rooms 탭 UI
-- 친구 검색/요청/수락/거절/차단
+- 카카오 계정 연결 / 해제
+- 친구 검색(이메일 기준), 요청, 수락, 거절, 차단
 - 친구 기반 1:1 방 재사용 / 그룹방 생성
-- 그룹방 생성/목록/입장
-- 실시간 메시지 송수신 + 메시지 히스토리 조회
+- 채팅방 초대 / 나가기
+- 실시간 메시지 송수신
+- 메시지 unread 숫자 표시
+- 방 목록 unread badge / 최근 메시지 정렬
+- 이전 메시지 커서 기반 로드
 - 알림 허브(Desktop 드롭다운 / Mobile 전용 화면)
 - 모바일 하단 탭바
-- 방 목록 unread count + 메시지 unread 숫자 표시
-- 참여자 목록(전체 멤버 + online/offline)
-- 방 검색 + FAB(+) 생성 모달
-- 사용자 메뉴(`내 정보`/`설정`/`로그아웃`)
-- 표준 에러 응답(`error.code`, `error.message`)
-- 운영 배포 기준 카카오 로그인 성공 검증
+- 내 정보 / 설정 분리 구조
+- 회원탈퇴 tombstone 처리
 
-## 3) 브랜딩 적용 상태
+## 3) 현재 상태
+
+- MVP2-B 1차 구현 완료
+- 인증/계정 UX 1차 재구성 완료
+- 브랜딩 및 아이콘 자산 1차 적용 완료
+- 실제 친구 계정 기준 E2E 검증은 추가 진행 필요
+
+## 4) 브랜딩 적용 상태
 
 브랜드 기준 문서:
 - `assets/branding/usage-guide.md`
 
-실사용 로고:
-- `assets/branding/logo/flownium-wordmark-light.png`
-- `assets/branding/logo/flownium-wordmark-dark.png`
-- `assets/branding/logo/flownium-icon.png`
+대표 자산:
+- `assets/branding/logo/flownium-logo_wordmark-on-light.png`
+- `assets/branding/logo/flownium-logo_wordmark-on-dark.png`
+- `assets/branding/logo/flownium-logo_icon.png`
+
+배포용 아이콘:
+- `public/branding/favicon-16x16.png`
+- `public/branding/favicon-32x32.png`
+- `public/branding/apple-touch-icon.png`
+- `public/branding/android-chrome-192x192.png`
+- `public/branding/android-chrome-512x512.png`
 
 UI 적용 원칙:
-1. 배경은 브랜드 그라데이션
-2. 실제 동작 패널/모달은 라이트 서피스
-3. CTA/강조는 Primary/Secondary 그라데이션 사용
+1. 테마는 `light / dark / system` 기준으로 동작
+2. 로그인/인증 화면도 시스템 테마를 따라감
+3. 브랜드 워드마크는 `on-light / on-dark`를 테마에 맞게 분기
 
-## 4) 기술 구조 요약
+## 5) 기술 구조 요약
 
 프론트:
-- React + Vite
-- `AppShell` 조합 구조
-- `features/*`(화면/상태), `services/*`(I/O), `domain/*`(규칙)
+- React + Vite + Tailwind CSS
+- `AppShell` 조립 구조
+- `features/*` 기능 단위
+- `services/*` REST / Socket I/O
+- `domain/*` 사용자/세션 정규화
 
 백엔드:
 - Express + Socket.IO
-- MongoDB(Mongoose)
+- MongoDB (Mongoose)
 - 라우트 분리(`auth`, `chatrooms`, `friends`, `notifications`)
 
 운영 배포:
@@ -64,18 +79,26 @@ UI 적용 원칙:
 - Backend: Render
 - DB: MongoDB Atlas
 
-## 5) 운영 상태
+## 6) 계정 정책 요약
 
-- 로컬/운영 환경 모두 카카오 로그인 흐름 검증 가능
-- 프론트 API URL: `VITE_API_BASE_URL` 우선, 미설정 시 `http://localhost:3010` fallback
-- 카카오 Redirect URI는 프론트/서버/카카오 콘솔에서 동일 문자열이어야 함
-- 기본 정책은 끝 슬래시 없는 URI(`https://flownium-chat-2-0.vercel.app`)로 통일
-- 서버 시작 시 레거시 `roomKey_1` 인덱스 자동 제거
+- `User`는 서비스 내부 사용자 본체
+- `AuthIdentity`는 로그인 수단 매핑
+- 카카오는 회원 본체가 아니라 간편로그인 수단
+- 이메일 회원가입과 카카오 로그인을 자동 병합하지 않음
+- 이메일 회원은 명시적으로 카카오 계정을 연결할 수 있음
+- 회원탈퇴 시 `User`는 tombstone으로 남기고 로그인 수단은 제거
+- 같은 카카오 계정 재가입은 기존 tombstone 복구가 아니라 새 사용자 흐름
 
-## 6) 다음 우선순위
+## 7) 운영 상태
 
-1. 실제 친구 계정 2개 기준 친구 요청/수락/1:1 재사용/그룹 생성 E2E 검증
-2. unread 감소/증가와 알림 실시간 반영 최종 검증
-3. 설정 화면을 별도 화면 구조로 확장
-4. MVP2 화면/오브젝트 정의서 상세화
-5. 회원탈퇴는 다음 scope 후보로 별도 정리
+- 로컬/운영 환경 모두 카카오 로그인 흐름 1차 검증 완료
+- 이메일 회원가입/인증/로그인/비밀번호 재설정은 개발 단계 `debugCode` 기반 검증 가능
+- 서버 시작 시 레거시 `roomKey_1`, `users.kakaoId_1` 인덱스 자동 제거
+
+## 8) 다음 우선순위
+
+1. 실제 친구 계정 2개 기준 채팅/알림/unread E2E 검증
+2. 계정 연결/병합 정책 설계
+3. 실제 SMTP 또는 메일 서비스 연결 전략 확정
+4. 이메일 변경 기능
+5. 익명방/비회원 도메인 상세 설계


### PR DESCRIPTION
﻿Title
refresh project overview and auth docs

Summary
현재 구현 상태와 문서 인덱스가 어긋나 있던 부분을 정리했습니다. 루트 README, 문서 인덱스, 프로젝트 개요, 인증 흐름 문서를 최신 제품 상태 기준으로 다시 맞췄습니다.

Changed Files
- C:\Users\yoooo\flownium-chat-2.0\README.md
- C:\Users\yoooo\flownium-chat-2.0\docs\README.md
- C:\Users\yoooo\flownium-chat-2.0\docs\common\auth-flow.md
- C:\Users\yoooo\flownium-chat-2.0\docs\common\project-overview.md
- C:\Users\yoooo\flownium-chat-2.0\.codex\worklogs\2026-03-12-docs-project-overview-refresh.md

What’s Included
- 루트 README를 현재 기능 세트 기준으로 재정리
- docs/README 문서 인덱스 갱신
- project-overview를 최신 제품 상태와 브랜딩 자산 경로 기준으로 갱신
- auth-flow를 이메일 인증, 비밀번호 재설정, 카카오 연결/해제, tombstone 정책 기준으로 재작성
- 작업 기록용 worklog 추가

Impact
- 루트 프로젝트 안내
- 문서 인덱스
- 인증 구조 이해
- 제품 개요 문서

Validation
- 문서 diff 및 파일 내용 확인

Branch / Commit
- Branch: docs/project-overview-refresh
- Commit: 9d6dc41
- Push: origin/docs/project-overview-refresh

PR
- pending

Issue Closure
- None
