### PR TITLE
style: tune auth typography with sora

### DIFF
--- a/.codex/worklogs/2026-03-12-feature-ui-icon-assets.md
+++ b/.codex/worklogs/2026-03-12-feature-ui-icon-assets.md
@@ -30,3 +30,6 @@
 - generated SVG icons are intended as a shippable first pass and can later be replaced with AI-generated variants if needed
 - adjusted the top notification button so the bell icon sits centered within the 36x36 action button
 - split the previous settings icon into a dedicated `theme.svg` and a clearer gear-style `settings.svg`
+- loaded `Sora` explicitly in `index.html` and aligned the auth gate typography with the product font stack
+- softened the auth gate typography by reducing heading, label, and button font weights for better readability on dark backgrounds
+- reduced auth CTA brightness and shadow intensity so login/signup/reset screens feel less harsh on dark theme

--- a/index.html
+++ b/index.html
@@ -2,6 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Sora:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
     <link rel="icon" type="image/png" sizes="32x32" href="/branding/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/branding/favicon-16x16.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/branding/apple-touch-icon.png" />

--- a/src/features/auth/components/LoginGate.css
+++ b/src/features/auth/components/LoginGate.css
@@ -49,7 +49,7 @@
 .auth-panel-eyebrow {
   color: var(--text-tertiary);
   font-size: 11px;
-  font-weight: 800;
+  font-weight: 700;
   letter-spacing: 0.22em;
   text-transform: uppercase;
 }
@@ -59,7 +59,8 @@
   color: var(--text-primary);
   font-size: clamp(28px, 5vw, 38px);
   line-height: 1.08;
-  letter-spacing: -0.04em;
+  font-weight: 600;
+  letter-spacing: -0.025em;
 }
 
 .auth-hero p,
@@ -68,6 +69,7 @@
   color: var(--text-secondary);
   font-size: 14px;
   line-height: 1.65;
+  font-weight: 500;
 }
 
 .auth-error-banner {
@@ -78,7 +80,7 @@
   color: #991b1b;
   padding: 14px 16px;
   font-size: 13px;
-  font-weight: 800;
+  font-weight: 700;
   line-height: 1.6;
   box-shadow: 0 10px 24px rgba(220, 38, 38, 0.08);
 }
@@ -96,7 +98,7 @@
   color: #1d4ed8;
   padding: 14px 16px;
   font-size: 13px;
-  font-weight: 800;
+  font-weight: 700;
   line-height: 1.6;
 }
 
@@ -116,12 +118,12 @@
   height: 50px;
   border: none;
   border-radius: 16px;
-  background: var(--cta-bg);
+  background: linear-gradient(135deg, rgba(91, 92, 255, 0.8) 0%, rgba(114, 109, 255, 0.76) 100%);
   color: var(--cta-text);
-  font-size: 15px;
-  font-weight: 800;
+  font-size: 14px;
+  font-weight: 600;
   cursor: pointer;
-  box-shadow: var(--shadow-glow);
+  box-shadow: 0 8px 18px rgba(91, 92, 255, 0.12);
 }
 
 .kakao-login-button:hover,
@@ -147,7 +149,7 @@
   gap: 12px;
   color: var(--text-tertiary);
   font-size: 12px;
-  font-weight: 700;
+  font-weight: 600;
 }
 
 .auth-divider::before,
@@ -175,7 +177,9 @@
 .auth-panel-header h2 {
   margin: 0;
   color: var(--text-primary);
-  font-size: 20px;
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
 }
 
 .auth-panel-header p {
@@ -183,6 +187,7 @@
   color: var(--text-secondary);
   font-size: 13px;
   line-height: 1.6;
+  font-weight: 500;
 }
 
 .auth-form {
@@ -198,7 +203,8 @@
 .auth-field span {
   color: var(--text-secondary);
   font-size: 12px;
-  font-weight: 800;
+  font-weight: 700;
+  letter-spacing: -0.01em;
 }
 
 .auth-field input {
@@ -312,14 +318,15 @@
   height: 46px;
   border-radius: 16px;
   font-size: 14px;
-  font-weight: 800;
+  font-weight: 600;
   cursor: pointer;
 }
 
 .email-action-button {
   border: none;
-  background: var(--cta-bg);
+  background: linear-gradient(135deg, rgba(91, 92, 255, 0.8) 0%, rgba(114, 109, 255, 0.76) 100%);
   color: var(--cta-text);
+  box-shadow: 0 8px 18px rgba(91, 92, 255, 0.12);
 }
 
 .secondary-action-button {

--- a/src/index.css
+++ b/src/index.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 :root {
-  font-family: "Noto Sans KR", "Apple SD Gothic Neo", "Malgun Gothic", system-ui, -apple-system, sans-serif;
+  font-family: "Sora", "Noto Sans KR", "Apple SD Gothic Neo", "Malgun Gothic", system-ui, -apple-system, sans-serif;
   line-height: 1.5;
   font-weight: 400;
   font-synthesis: none;


### PR DESCRIPTION
﻿Title
style: tune auth typography with sora

Summary
로그인 화면에서 Sora 폰트가 실제로 로드되지 않던 문제를 정리하고, 다크 배경에서 과하게 강하게 보이던 인증 화면 타이포와 CTA 강도를 부드럽게 조정했습니다.

Changed Files
- .codex/worklogs/2026-03-12-feature-ui-icon-assets.md
- index.html
- src/features/auth/components/LoginGate.css
- src/index.css

What’s Included
- index.html에 Sora 폰트 로딩 링크 추가
- 전역 폰트 스택을 Sora 우선으로 정리
- 로그인/회원가입/비밀번호 재설정 화면의 제목, 레이블, 버튼 텍스트 font weight 하향 조정
- auth CTA의 그라디언트 밝기와 그림자 강도 완화
- 관련 worklog 업데이트

Impact
- 로그인 화면 타이포그래피
- 인증 CTA 시각 강도
- 전역 폰트 로딩

Validation
- npm run build

Branch / Commit
- Branch: fix/auth-typography-sora
- Commit: f7ca91f
- Push: origin/fix/auth-typography-sora

PR
- pending
