### PR TITLE
refactor: scope account and menu styles

### DIFF
--- a/.codex/worklogs/2026-03-12-refactor-account-panel-styles.md
+++ b/.codex/worklogs/2026-03-12-refactor-account-panel-styles.md
@@ -1,0 +1,31 @@
+# 2026-03-12 - Refactor account and menu styles
+
+## Summary
+
+- moved `AccountPanel`-specific styles out of `src/App.css` into a dedicated component stylesheet
+- moved `NotificationMenu` and `UserMenu` styles next to their components
+- kept the settings theme control as a native dropdown and applied app-specific select styling instead of changing the control type
+- kept shared modal, settings shell, and app-shell styles in `App.css`
+- aimed to reduce accidental style bleed from account polishing into unrelated screens such as login
+
+## Changed Files
+
+- `src/App.css`
+- `src/features/user/components/AccountPanel.jsx`
+- `src/features/user/components/AccountPanel.css`
+- `src/features/notifications/components/NotificationMenu.jsx`
+- `src/features/notifications/components/NotificationMenu.css`
+- `src/features/user/components/UserMenu.jsx`
+- `src/features/user/components/UserMenu.css`
+- `src/features/user/components/SettingsScreen.jsx`
+- `src/features/user/components/SettingsModal.jsx`
+
+## Validation
+
+- `npm install`
+- `npm run build`
+
+## Notes
+
+- `npm install` was run to repair a broken local Vite/Rolldown install before validation
+- no API, route, or data-flow changes were made in this task

--- a/src/App.css
+++ b/src/App.css
@@ -96,45 +96,65 @@
   padding: 0 14px;
 }
 
-.settings-field select {
-  width: 100%;
-  height: 46px;
-  border: 1px solid var(--border-soft);
-  border-radius: 18px;
-  background: var(--surface-elevated);
-  color: var(--brand-text);
-  outline: none;
-  padding: 0 44px 0 14px;
-  appearance: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  background-image:
-    linear-gradient(45deg, transparent 50%, var(--text-secondary) 50%),
-    linear-gradient(135deg, var(--text-secondary) 50%, transparent 50%);
-  background-position:
-    calc(100% - 20px) calc(50% - 1px),
-    calc(100% - 14px) calc(50% - 1px);
-  background-size: 6px 6px, 6px 6px;
-  background-repeat: no-repeat;
-  color-scheme: light;
-  transition: border-color 160ms ease, background-color 160ms ease, color 160ms ease;
-}
-
-.settings-field select:focus {
-  border-color: rgba(91, 92, 255, 0.45);
-}
-
-.settings-field select option {
-  background: #ffffff;
-  color: #111827;
-}
-
 .settings-field input::placeholder {
   color: rgba(154, 163, 178, 0.8);
 }
 
 .settings-field input:focus {
   border-color: rgba(91, 92, 255, 0.45);
+}
+
+.settings-field select {
+  width: 100%;
+  height: 46px;
+  border: 1px solid color-mix(in srgb, var(--brand-primary) 22%, var(--border-soft));
+  border-radius: 18px;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--panel-soft) 74%, transparent), color-mix(in srgb, var(--surface-elevated) 92%, transparent)),
+    var(--surface-elevated);
+  color: var(--brand-text);
+  outline: none;
+  padding: 0 44px 0 14px;
+  font: inherit;
+  font-weight: 600;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-image:
+    linear-gradient(180deg, color-mix(in srgb, var(--panel-soft) 74%, transparent), color-mix(in srgb, var(--surface-elevated) 92%, transparent)),
+    linear-gradient(45deg, transparent 50%, var(--brand-subtext) 50%),
+    linear-gradient(135deg, var(--brand-subtext) 50%, transparent 50%);
+  background-repeat: no-repeat;
+  background-size: auto, 8px 8px, 8px 8px;
+  background-position: 0 0, calc(100% - 20px) calc(50% - 2px), calc(100% - 14px) calc(50% - 2px);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+}
+
+.settings-field select:hover {
+  border-color: rgba(91, 92, 255, 0.32);
+  background-image:
+    linear-gradient(180deg, color-mix(in srgb, var(--brand-primary) 8%, var(--panel-soft)), color-mix(in srgb, var(--surface-elevated) 88%, transparent)),
+    linear-gradient(45deg, transparent 50%, var(--brand-text) 50%),
+    linear-gradient(135deg, var(--brand-text) 50%, transparent 50%);
+}
+
+.settings-field select:focus {
+  border-color: rgba(91, 92, 255, 0.45);
+  box-shadow: 0 0 0 3px rgba(91, 92, 255, 0.16);
+}
+
+.settings-field select option {
+  background: #ffffff;
+  color: #1f2328;
+}
+
+:root[data-resolved-theme='dark'] .settings-field select {
+  color-scheme: dark;
+}
+
+:root[data-resolved-theme='dark'] .settings-field select option {
+  background: #161b2f;
+  color: #f5f7ff;
 }
 
 .back-button {
@@ -174,8 +194,7 @@
   color: #22c55e;
 }
 
-.muted-text,
-.notification-empty {
+.muted-text {
   color: var(--brand-subtext);
 }
 
@@ -251,7 +270,6 @@
 
 .modal-actions button,
 .profile-modal button,
-.notification-actions button,
 .inline-action-button {
   height: 42px;
   border: none;
@@ -264,7 +282,6 @@
 
 .modal-actions button:hover,
 .profile-modal button:hover,
-.notification-actions button:hover,
 .inline-action-button:hover {
   filter: brightness(1.08);
 }
@@ -277,7 +294,6 @@
 }
 
 .modal-actions .secondary,
-.notification-actions .secondary,
 .inline-action-button.secondary,
 .single-column-actions .secondary {
   background: var(--surface-muted);
@@ -308,8 +324,7 @@
 }
 
 .friend-search-list,
-.friend-picker-list,
-.notification-list {
+.friend-picker-list {
   margin: 0;
   padding: 0;
   list-style: none;
@@ -323,8 +338,7 @@
   overflow: auto;
 }
 
-.friend-search-row,
-.notification-row {
+.friend-search-row {
   display: grid;
   grid-template-columns: auto 1fr auto;
   gap: 10px;
@@ -386,8 +400,7 @@
   font-size: 17px;
 }
 
-.friend-main,
-.notification-main {
+.friend-main {
   min-width: 0;
   display: flex;
   flex-direction: column;
@@ -395,21 +408,17 @@
 }
 
 .friend-main strong,
-.friend-main small,
-.notification-main strong,
-.notification-main small {
+.friend-main small {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.friend-main strong,
-.notification-main strong {
+.friend-main strong {
   color: var(--brand-text);
 }
 
 .friend-main small,
-.notification-main small,
 .selection-indicator,
 .notification-section-title,
 .profile-modal-id {
@@ -487,198 +496,14 @@
   font-size: 20px;
 }
 
-.account-panel {
-  display: grid;
-  gap: 16px;
-}
-
-.account-inline-actions {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 10px;
-}
-
-.account-panel-hero {
-  display: flex;
-  align-items: center;
-  gap: 14px;
-  padding: 12px 16px;
-  border: 1px solid var(--border-soft);
-  border-radius: 22px;
-  background: var(--surface-muted);
-}
-
-.account-panel-avatar {
-  margin: 0;
-  flex-shrink: 0;
-  align-self: center;
-  width: 78px;
-  height: 78px;
-  border-radius: 28px;
-}
-
-.account-panel-summary {
-  min-width: 0;
-  display: grid;
-  gap: 6px;
-  align-content: center;
-}
-
-.account-panel-summary h3 {
-  margin: 0;
-  color: var(--brand-text);
-  font-size: 20px;
-}
-
-.account-panel-summary p {
-  margin: 0;
-}
-
-.account-panel-meta {
-  display: grid;
-  gap: 6px;
-}
-
-.account-panel-email {
-  color: var(--brand-text);
-  font-size: 14px;
-  font-weight: 600;
-  line-height: 1.4;
-}
-
-.account-panel-email-fallback {
-  color: var(--brand-subtext);
-  font-size: 13px;
-  font-weight: 500;
-}
-
-.account-provider-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.account-provider-chip {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 28px;
-  border-radius: 999px;
-  padding: 0 12px;
-  border: 1px solid var(--border-soft);
-  background: var(--surface-elevated);
-  color: var(--brand-text);
-  font-size: 12px;
-  font-weight: 700;
-}
-
-.account-highlight-card {
-  display: grid;
-  gap: 6px;
-  border: 1px solid rgba(91, 92, 255, 0.24);
-  border-radius: 20px;
-  background: color-mix(in srgb, var(--brand-primary) 10%, var(--surface-elevated));
-  padding: 14px;
-}
-
-.account-highlight-card strong {
-  color: var(--brand-text);
-}
-
-.account-section {
-  display: grid;
-  gap: 12px;
-  border: 1px solid var(--border-soft);
-  border-radius: 22px;
-  background: var(--surface-muted);
-  padding: 16px;
-}
-
-.account-section-header {
-  display: grid;
-  gap: 4px;
-}
-
-.account-section-header h4 {
-  margin: 0;
-  color: var(--brand-text);
-  font-size: 15px;
-}
-
-.account-section-header p {
-  margin: 0;
-}
-
-.account-section-danger {
-  border-color: rgba(248, 113, 113, 0.24);
-}
-
-.account-feedback {
-  margin-bottom: 0;
-}
-
 .profile-modal-avatar {
   margin: 8px auto;
   border-radius: 999px;
 }
 
-.account-panel-hero .account-panel-avatar {
-  margin: 0;
-}
-
 .profile-modal-name {
   margin: 0;
   color: var(--brand-text);
-  font-weight: 700;
-}
-
-.subtle-scroll {
-  scrollbar-width: thin;
-  scrollbar-color: color-mix(in srgb, var(--text-tertiary) 42%, transparent) transparent;
-}
-
-.subtle-scroll::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
-}
-
-.subtle-scroll::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.subtle-scroll::-webkit-scrollbar-thumb {
-  border: 2px solid transparent;
-  border-radius: 999px;
-  background-clip: padding-box;
-  background: color-mix(in srgb, var(--text-tertiary) 40%, transparent);
-}
-
-.subtle-scroll::-webkit-scrollbar-thumb:hover {
-  background: color-mix(in srgb, var(--text-secondary) 54%, transparent);
-}
-
-.notification-menu,
-.user-menu {
-  position: relative;
-}
-
-.panel-top-actions .notification-menu,
-.panel-top-actions .user-menu {
-  flex-shrink: 0;
-}
-
-.notification-button,
-.kebab-button {
-  width: 36px;
-  height: 36px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid var(--border-soft);
-  border-radius: 14px;
-  background: var(--surface-elevated);
-  color: var(--brand-text);
-  font-size: 16px;
   font-weight: 700;
 }
 
@@ -696,157 +521,8 @@
   display: block;
 }
 
-.notification-button:hover,
-.kebab-button:hover {
-  background: var(--surface-muted);
-}
-
-.user-menu .user-menu-dropdown,
-.notification-dropdown {
-  position: absolute;
-  right: 0;
-  top: calc(100% + 10px);
-  z-index: 40;
-  border: 1px solid var(--border-soft);
-  background: var(--panel-raised);
-  backdrop-filter: blur(18px);
-  box-shadow: 0 24px 60px rgba(2, 6, 23, 0.5);
-}
-
-.user-menu-dropdown {
-  width: 160px;
-  display: grid;
-  gap: 4px;
-  padding: 8px;
-  border-radius: 18px;
-}
-
-.user-menu-dropdown button {
-  border: none;
-  border-radius: 12px;
-  background: transparent;
-  color: var(--brand-text);
-  padding: 10px;
-  text-align: left;
-}
-
-.user-menu-dropdown button:hover {
-  background: var(--surface-muted);
-}
-
-.user-menu-dropdown button.danger {
-  color: #fda4af;
-}
-
-.notification-button {
-  position: relative;
-}
-
-.notification-button-icon {
-  transform: translateY(0.5px);
-}
-
-.notification-badge {
-  position: absolute;
-  top: -6px;
-  right: -4px;
-  min-width: 18px;
-  height: 18px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 999px;
-  padding: 0 5px;
-  background: var(--badge-bg);
-  color: white;
-  font-size: 10px;
-  font-weight: 700;
-}
-
-.notification-dropdown {
-  width: min(92vw, 380px);
-  max-height: min(72vh, 560px);
-  overflow: auto;
-  border-radius: 24px;
-  padding: 16px;
-}
-
-.notification-header {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  margin-bottom: 12px;
-  color: var(--brand-text);
-}
-
-.notification-header small {
-  color: var(--brand-subtext);
-}
-
-.notification-section {
-  margin-top: 10px;
-  padding-top: 10px;
-  border-top: 1px solid var(--border-soft);
-}
-
-.notification-section:first-of-type {
-  margin-top: 0;
-  padding-top: 0;
-  border-top: none;
-}
-
-.notification-section-title {
-  margin-bottom: 10px;
-  font-weight: 700;
-  letter-spacing: 0.02em;
-}
-
-.notification-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: 12px;
-  align-items: center;
-  border-radius: 18px;
-  background: var(--surface-muted);
-  padding: 14px;
-}
-
-.notification-row.actionable {
-  grid-template-columns: minmax(0, 1fr) auto;
-}
-
-.notification-row.unread {
-  border: 1px solid rgba(91, 92, 255, 0.22);
-}
-
-.notification-actions {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-}
-
-.notification-summary {
-  margin: 0;
-  color: var(--brand-subtext);
-  font-size: 13px;
-  line-height: 1.45;
-}
-
-.notification-time {
-  color: var(--brand-subtext);
-  font-size: 11px;
-  opacity: 0.9;
-}
-
 .mobile-bottom-tabbar {
   display: none;
-}
-
-@media (max-width: 1023px) {
-  .panel-top-actions .notification-menu,
-  .panel-top-actions .user-menu {
-    display: none;
-  }
 }
 
 @media (max-width: 767px) {
@@ -869,10 +545,6 @@
   .notification-screen.mobile-active,
   .settings-screen.mobile-active {
     padding-bottom: 76px;
-  }
-
-  .account-inline-actions {
-    grid-template-columns: 1fr;
   }
 
   .back-button {

--- a/src/features/notifications/components/NotificationMenu.css
+++ b/src/features/notifications/components/NotificationMenu.css
@@ -1,0 +1,188 @@
+.notification-menu {
+  position: relative;
+}
+
+.panel-top-actions .notification-menu {
+  flex-shrink: 0;
+}
+
+.notification-button {
+  position: relative;
+  width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border-soft);
+  border-radius: 14px;
+  background: var(--surface-elevated);
+  color: var(--brand-text);
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.notification-button:hover {
+  background: var(--surface-muted);
+}
+
+.notification-button-icon {
+  transform: translateY(0.5px);
+}
+
+.notification-badge {
+  position: absolute;
+  top: -6px;
+  right: -4px;
+  min-width: 18px;
+  height: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 0 5px;
+  background: var(--badge-bg);
+  color: white;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.notification-dropdown {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 10px);
+  z-index: 40;
+  width: min(92vw, 380px);
+  max-height: min(72vh, 560px);
+  overflow: auto;
+  border: 1px solid var(--border-soft);
+  border-radius: 24px;
+  background: var(--panel-raised);
+  backdrop-filter: blur(18px);
+  box-shadow: 0 24px 60px rgba(2, 6, 23, 0.5);
+  padding: 16px;
+}
+
+.notification-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 12px;
+  color: var(--brand-text);
+}
+
+.notification-header small {
+  color: var(--brand-subtext);
+}
+
+.notification-section {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border-soft);
+}
+
+.notification-section:first-of-type {
+  margin-top: 0;
+  padding-top: 0;
+  border-top: none;
+}
+
+.notification-section-title {
+  margin-bottom: 10px;
+  color: var(--brand-subtext);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.notification-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.notification-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 12px;
+  align-items: center;
+  border-radius: 18px;
+  background: var(--surface-muted);
+  padding: 14px;
+}
+
+.notification-row.actionable {
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.notification-row.unread {
+  border: 1px solid rgba(91, 92, 255, 0.22);
+}
+
+.notification-main {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.notification-main strong,
+.notification-main small {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.notification-main strong {
+  color: var(--brand-text);
+}
+
+.notification-summary {
+  margin: 0;
+  color: var(--brand-subtext);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.notification-time {
+  color: var(--brand-subtext);
+  font-size: 11px;
+  opacity: 0.9;
+}
+
+.notification-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.notification-actions button {
+  height: 42px;
+  border: none;
+  border-radius: 16px;
+  padding: 0 14px;
+  background: var(--cta-bg);
+  color: var(--cta-text);
+  font-weight: 700;
+}
+
+.notification-actions button:hover {
+  filter: brightness(1.08);
+}
+
+.notification-actions .secondary {
+  background: var(--surface-muted);
+  color: var(--brand-text);
+}
+
+.notification-empty {
+  color: var(--brand-subtext);
+}
+
+@media (max-width: 1023px) {
+  .panel-top-actions .notification-menu {
+    display: none;
+  }
+}

--- a/src/features/notifications/components/NotificationMenu.jsx
+++ b/src/features/notifications/components/NotificationMenu.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
 import notificationIcon from '../../../../assets/branding/icons/system/notifications.svg?raw'
 import InlineIcon from '../../../components/InlineIcon'
+import './NotificationMenu.css'
 
 const toCreatedLabel = (value) => {
   if (!value) return ''

--- a/src/features/user/components/AccountPanel.css
+++ b/src/features/user/components/AccountPanel.css
@@ -1,0 +1,164 @@
+.account-panel {
+  display: grid;
+  gap: 16px;
+}
+
+.account-inline-actions {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+}
+
+.account-panel-hero {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 16px;
+  border: 1px solid var(--border-soft);
+  border-radius: 22px;
+  background: var(--surface-muted);
+}
+
+.account-panel-avatar {
+  margin: 0;
+  flex-shrink: 0;
+  align-self: center;
+  width: 78px;
+  height: 78px;
+  border-radius: 28px;
+}
+
+.account-panel-summary {
+  min-width: 0;
+  display: grid;
+  gap: 6px;
+  align-content: center;
+}
+
+.account-panel-summary h3 {
+  margin: 0;
+  color: var(--brand-text);
+  font-size: 20px;
+}
+
+.account-panel-summary p {
+  margin: 0;
+}
+
+.account-panel-meta {
+  display: grid;
+  gap: 6px;
+}
+
+.account-panel-email {
+  color: var(--brand-text);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.account-panel-email-fallback {
+  color: var(--brand-subtext);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.account-provider-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.account-provider-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 28px;
+  border-radius: 999px;
+  padding: 0 12px;
+  border: 1px solid var(--border-soft);
+  background: var(--surface-elevated);
+  color: var(--brand-text);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.account-highlight-card {
+  display: grid;
+  gap: 6px;
+  border: 1px solid rgba(91, 92, 255, 0.24);
+  border-radius: 20px;
+  background: color-mix(in srgb, var(--brand-primary) 10%, var(--surface-elevated));
+  padding: 14px;
+}
+
+.account-highlight-card strong {
+  color: var(--brand-text);
+}
+
+.account-section {
+  display: grid;
+  gap: 12px;
+  border: 1px solid var(--border-soft);
+  border-radius: 22px;
+  background: var(--surface-muted);
+  padding: 16px;
+}
+
+.account-section-header {
+  display: grid;
+  gap: 4px;
+}
+
+.account-section-header h4 {
+  margin: 0;
+  color: var(--brand-text);
+  font-size: 15px;
+}
+
+.account-section-header p {
+  margin: 0;
+}
+
+.account-section-danger {
+  border-color: rgba(248, 113, 113, 0.24);
+}
+
+.account-feedback {
+  margin-bottom: 0;
+}
+
+.account-panel-hero .account-panel-avatar {
+  margin: 0;
+}
+
+.subtle-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--text-tertiary) 42%, transparent) transparent;
+}
+
+.subtle-scroll::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.subtle-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.subtle-scroll::-webkit-scrollbar-thumb {
+  border: 2px solid transparent;
+  border-radius: 999px;
+  background-clip: padding-box;
+  background: color-mix(in srgb, var(--text-tertiary) 40%, transparent);
+}
+
+.subtle-scroll::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, var(--text-secondary) 54%, transparent);
+}
+
+@media (max-width: 767px) {
+  .account-inline-actions {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/features/user/components/AccountPanel.jsx
+++ b/src/features/user/components/AccountPanel.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { UserProfile } from '../../../domain/user/UserProfile'
+import './AccountPanel.css'
 
 const getLinkedProviderLabel = (provider) => {
   if (provider === 'kakao') return '카카오'

--- a/src/features/user/components/SettingsModal.jsx
+++ b/src/features/user/components/SettingsModal.jsx
@@ -1,4 +1,4 @@
-// 설정 모달은 앱 환경 설정만 다룬다. 계정 정보 관리는 내 정보 화면으로 분리한다.
+// 설정 모달은 화면 테마만 다루고, 계정 정보 관리는 내 정보 화면으로 분리한다.
 function SettingsModal({ isOpen, themePreference, onChangeTheme, onClose }) {
   if (!isOpen) return null
 
@@ -8,14 +8,14 @@ function SettingsModal({ isOpen, themePreference, onChangeTheme, onClose }) {
         <h3>설정</h3>
         <p>앱에서 사용하는 화면 테마를 바꿀 수 있어요.</p>
 
-        <label className="settings-field">
+        <div className="settings-field">
           <span>테마</span>
           <select value={themePreference} onChange={(event) => onChangeTheme(event.target.value)}>
             <option value="system">시스템 설정 따르기</option>
             <option value="light">라이트 모드</option>
             <option value="dark">다크 모드</option>
           </select>
-        </label>
+        </div>
 
         <div className="modal-actions single-column-actions">
           <button type="button" className="secondary" onClick={onClose}>

--- a/src/features/user/components/SettingsScreen.jsx
+++ b/src/features/user/components/SettingsScreen.jsx
@@ -13,14 +13,14 @@ function SettingsScreen({ themePreference, onChangeTheme, onBack }) {
 
       <div className="settings-screen-body">
         <div className="settings-form-card">
-          <label className="settings-field">
+          <div className="settings-field">
             <span>테마</span>
             <select value={themePreference} onChange={(event) => onChangeTheme(event.target.value)}>
               <option value="system">시스템 설정 따르기</option>
               <option value="light">라이트 모드</option>
               <option value="dark">다크 모드</option>
             </select>
-          </label>
+          </div>
         </div>
       </div>
     </section>

--- a/src/features/user/components/UserMenu.css
+++ b/src/features/user/components/UserMenu.css
@@ -1,0 +1,64 @@
+.user-menu {
+  position: relative;
+}
+
+.panel-top-actions .user-menu {
+  flex-shrink: 0;
+}
+
+.kebab-button {
+  width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border-soft);
+  border-radius: 14px;
+  background: var(--surface-elevated);
+  color: var(--brand-text);
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.kebab-button:hover {
+  background: var(--surface-muted);
+}
+
+.user-menu-dropdown {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 10px);
+  z-index: 40;
+  width: 160px;
+  display: grid;
+  gap: 4px;
+  padding: 8px;
+  border: 1px solid var(--border-soft);
+  border-radius: 18px;
+  background: var(--panel-raised);
+  backdrop-filter: blur(18px);
+  box-shadow: 0 24px 60px rgba(2, 6, 23, 0.5);
+}
+
+.user-menu-dropdown button {
+  border: none;
+  border-radius: 12px;
+  background: transparent;
+  color: var(--brand-text);
+  padding: 10px;
+  text-align: left;
+}
+
+.user-menu-dropdown button:hover {
+  background: var(--surface-muted);
+}
+
+.user-menu-dropdown button.danger {
+  color: #fda4af;
+}
+
+@media (max-width: 1023px) {
+  .panel-top-actions .user-menu {
+    display: none;
+  }
+}

--- a/src/features/user/components/UserMenu.jsx
+++ b/src/features/user/components/UserMenu.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
 import menuIcon from '../../../../assets/branding/icons/system/menu.svg?raw'
 import InlineIcon from '../../../components/InlineIcon'
+import './UserMenu.css'
 
 // 사용자 메뉴는 상단 우측 액션 영역에서 내 정보/설정/로그아웃 진입점을 담당한다.
 // 버튼 기호를 외부에서 주입할 수 있게 열어둬서 헤더 레이아웃에 맞게 재사용한다.


### PR DESCRIPTION
﻿Title
refactor: scope account and menu styles

Summary
This change narrows style ownership for account and menu surfaces so we can keep polishing those screens without leaking side effects into unrelated UI. It also keeps the settings theme control as a native dropdown while styling it to fit the existing visual system.

Changed Files
- C:\Users\yoooo\flownium-chat-2.0\src\App.css
- C:\Users\yoooo\flownium-chat-2.0\src\features\notifications\components\NotificationMenu.css
- C:\Users\yoooo\flownium-chat-2.0\src\features\notifications\components\NotificationMenu.jsx
- C:\Users\yoooo\flownium-chat-2.0\src\features\user\components\AccountPanel.css
- C:\Users\yoooo\flownium-chat-2.0\src\features\user\components\AccountPanel.jsx
- C:\Users\yoooo\flownium-chat-2.0\src\features\user\components\SettingsModal.jsx
- C:\Users\yoooo\flownium-chat-2.0\src\features\user\components\SettingsScreen.jsx
- C:\Users\yoooo\flownium-chat-2.0\src\features\user\components\UserMenu.css
- C:\Users\yoooo\flownium-chat-2.0\src\features\user\components\UserMenu.jsx
- C:\Users\yoooo\flownium-chat-2.0\.codex\worklogs\2026-03-12-refactor-account-panel-styles.md

What’s Included
- Move AccountPanel-specific styles out of App.css into AccountPanel.css
- Move NotificationMenu-specific styles out of App.css into NotificationMenu.css
- Move UserMenu-specific styles out of App.css into UserMenu.css
- Keep the settings theme control as a native select and apply app-specific dropdown styling
- Reduce shared style bleed in App.css by leaving only common shell and modal styles there

Impact
- Account screen styling
- Notification menu styling
- User menu styling
- Settings theme dropdown styling
- Shared app stylesheet organization

Validation
- npm install
- npm run build

Branch / Commit
- Branch: feat/account-management-polish
- Commit: 5ec74c5
- Push: origin/feat/account-management-polish

PR
- pending
