### PR TITLE
fix: align chat entry scroll to latest message

### DIFF
--- a/.codex/worklogs/2026-03-12-fix-chat-scroll-bottom.md
+++ b/.codex/worklogs/2026-03-12-fix-chat-scroll-bottom.md
@@ -1,0 +1,14 @@
+## Task
+- Fix chat room entry scroll so the view lands at the true bottom instead of stopping slightly above the last message.
+
+## Changes
+- Switched room-entry bottom alignment from `messagesEndRef.scrollIntoView()` to direct viewport scrolling with `scrollTop = scrollHeight`.
+- Updated `ChatPanel` to expose and use the actual history viewport ref, so `AppShell` can scroll the container itself.
+- Kept older-history restore logic intact.
+
+## Files
+- `src/app/AppShell.jsx`
+- `src/features/chat/components/ChatPanel.jsx`
+
+## Validation
+- `npm run build`

--- a/src/app/AppShell.jsx
+++ b/src/app/AppShell.jsx
@@ -48,7 +48,7 @@ const toTimeLabel = (value) => {
 }
 
 function AppShell() {
-  const messagesEndRef = useRef(null)
+  const chatHistoryViewportRef = useRef(null)
   const shouldScrollToBottomRef = useRef(false)
   const [themePreference, setThemePreference] = useState(() => {
     if (typeof window === 'undefined') return 'system'
@@ -373,13 +373,17 @@ function AppShell() {
   const previousRoomIdRef = useRef('')
 
   useLayoutEffect(() => {
-    if (!messagesEndRef.current || isLoadingHistory || isLoadingOlderHistory) return
+    if (!chatHistoryViewportRef.current || isLoadingHistory || isLoadingOlderHistory) return
 
     const roomChanged = shouldScrollToBottomRef.current || previousRoomIdRef.current !== joinedRoomId
     const appendedNewMessage = lastMessageMutation === 'append'
 
     if (joinedRoomId && (roomChanged || appendedNewMessage)) {
-      messagesEndRef.current.scrollIntoView({ behavior: roomChanged ? 'auto' : 'smooth', block: 'end' })
+      const viewport = chatHistoryViewportRef.current
+      viewport.scrollTo({
+        top: viewport.scrollHeight,
+        behavior: roomChanged ? 'auto' : 'smooth',
+      })
       shouldScrollToBottomRef.current = false
     }
 
@@ -859,7 +863,7 @@ function AppShell() {
           historyError={historyError}
           messages={messages}
           currentUserId={currentUser?.id || ''}
-          messagesEndRef={messagesEndRef}
+          historyViewportRef={chatHistoryViewportRef}
           onLoadOlderMessages={() => void loadOlderMessageHistory(joinedRoomId)}
           text={text}
           onTextChange={setText}

--- a/src/features/chat/components/ChatPanel.jsx
+++ b/src/features/chat/components/ChatPanel.jsx
@@ -17,7 +17,7 @@ function ChatPanel({
   historyError,
   messages,
   currentUserId,
-  messagesEndRef,
+  historyViewportRef,
   onLoadOlderMessages,
   text,
   onTextChange,
@@ -26,17 +26,19 @@ function ChatPanel({
   canSend,
   composerDisabledReason,
 }) {
-  const historyViewportRef = useRef(null)
+  const internalHistoryViewportRef = useRef(null)
   const restoreScrollRef = useRef(null)
 
+  const resolvedHistoryViewportRef = historyViewportRef || internalHistoryViewportRef
+
   useEffect(() => {
-    const viewport = historyViewportRef.current
+    const viewport = resolvedHistoryViewportRef.current
     if (!viewport || restoreScrollRef.current == null || isLoadingOlderHistory) return
 
     const previousScrollHeight = restoreScrollRef.current
     viewport.scrollTop = viewport.scrollHeight - previousScrollHeight
     restoreScrollRef.current = null
-  }, [isLoadingOlderHistory, messages.length])
+  }, [isLoadingOlderHistory, messages.length, resolvedHistoryViewportRef])
 
   const handleHistoryScroll = (event) => {
     const viewport = event.currentTarget
@@ -71,7 +73,7 @@ function ChatPanel({
       </div>
 
       <div
-        ref={historyViewportRef}
+        ref={resolvedHistoryViewportRef}
         className="min-h-0 overflow-auto bg-[linear-gradient(180deg,var(--panel-soft)_0%,transparent_100%)] px-4 py-4 md:px-5"
         onScroll={handleHistoryScroll}
       >
@@ -131,7 +133,6 @@ function ChatPanel({
             })}
           </ul>
         )}
-        <div ref={messagesEndRef} />
       </div>
 
       <div className="grid grid-cols-[1fr_auto] gap-3 border-t border-[var(--border-soft)] bg-[var(--panel-soft)] px-4 py-4 md:px-5">


### PR DESCRIPTION
﻿Title
fix: align chat entry scroll to latest message

Summary
채팅방 진입 시 마지막 메시지까지 보이긴 하지만 스크롤이 바닥보다 약간 위에서 멈추던 문제를 수정했다. 기존의 end sentinel `scrollIntoView()` 대신 실제 메시지 뷰포트를 직접 바닥까지 스크롤하도록 바꿔, 마지막 메시지 아래 공간이 남지 않게 정리했다.

Changed Files
- C:\Users\yoooo\flownium-chat-2.0\src\app\AppShell.jsx
- C:\Users\yoooo\flownium-chat-2.0\src\features\chat\components\ChatPanel.jsx
- C:\Users\yoooo\flownium-chat-2.0\.codex\worklogs\2026-03-12-fix-chat-scroll-bottom.md

What’s Included
- 방 진입/새 메시지 시 스크롤 기준을 `messagesEndRef.scrollIntoView()`에서 실제 history viewport 스크롤로 변경
- `ChatPanel`이 메시지 스크롤 컨테이너 ref를 외부에서 받을 수 있도록 정리
- 이전 메시지 더보기 시 스크롤 복원 로직은 그대로 유지
- task worklog 추가

Impact
- 채팅방 진입 시 초기 스크롤 위치
- 새 메시지 수신 후 하단 정렬 동작
- 채팅 히스토리 뷰포트 ref 관리

Validation
- npm run build

Branch / Commit
- Branch: fix/chat-scroll-bottom
- Commit: 33411d2
- Push: origin/fix/chat-scroll-bottom

PR
- pending
