### PR TITLE
fix: polish account management panel

### DIFF
--- a/.codex/worklogs/2026-03-12-account-management-finish.md
+++ b/.codex/worklogs/2026-03-12-account-management-finish.md
@@ -1,0 +1,15 @@
+## Task
+- Polish account management UI without affecting unrelated screens.
+
+## Changes
+- Rebuilt `AccountPanel` structure so feedback appears near the top instead of the bottom.
+- Added a compact login-method status section for email and Kakao linkage.
+- Grouped Kakao actions more clearly and kept all changes inside `AccountPanel.jsx` / `AccountPanel.css`.
+- Avoided touching global auth or chat styles.
+
+## Files
+- `src/features/user/components/AccountPanel.jsx`
+- `src/features/user/components/AccountPanel.css`
+
+## Validation
+- `npm run build`

--- a/src/features/user/components/AccountPanel.css
+++ b/src/features/user/components/AccountPanel.css
@@ -9,6 +9,10 @@
   gap: 10px;
 }
 
+.account-inline-actions-stack {
+  grid-template-columns: 1fr;
+}
+
 .account-panel-hero {
   display: flex;
   align-items: center;
@@ -96,6 +100,28 @@
   color: var(--brand-text);
 }
 
+.account-feedback-banner {
+  padding: 12px 14px;
+  border: 1px solid var(--border-soft);
+  border-radius: 18px;
+  background: var(--surface-muted);
+}
+
+.account-feedback-banner.is-error {
+  border-color: rgba(248, 113, 113, 0.28);
+  background: color-mix(in srgb, var(--brand-danger) 10%, var(--surface-muted));
+}
+
+.account-feedback-banner.is-success {
+  border-color: rgba(34, 197, 94, 0.24);
+  background: color-mix(in srgb, #22c55e 10%, var(--surface-muted));
+}
+
+.account-feedback-banner .error-text,
+.account-feedback-banner .success-text {
+  margin: 0;
+}
+
 .account-section {
   display: grid;
   gap: 12px;
@@ -118,6 +144,46 @@
 
 .account-section-header p {
   margin: 0;
+}
+
+.account-status-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.account-status-card {
+  display: grid;
+  gap: 6px;
+  padding: 14px;
+  border: 1px solid var(--border-soft);
+  border-radius: 18px;
+  background: var(--surface-elevated);
+}
+
+.account-status-card.is-active {
+  border-color: color-mix(in srgb, var(--brand-primary) 28%, var(--border-soft));
+  background: color-mix(in srgb, var(--brand-primary) 8%, var(--surface-elevated));
+}
+
+.account-status-card strong {
+  color: var(--brand-text);
+  font-size: 15px;
+}
+
+.account-status-card p {
+  margin: 0;
+  color: var(--brand-subtext);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.account-status-label {
+  color: var(--brand-subtext);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .account-section-danger {
@@ -159,6 +225,10 @@
 
 @media (max-width: 767px) {
   .account-inline-actions {
+    grid-template-columns: 1fr;
+  }
+
+  .account-status-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/src/features/user/components/AccountPanel.jsx
+++ b/src/features/user/components/AccountPanel.jsx
@@ -50,6 +50,7 @@ function AccountPanel({
   const linkedProviders = Array.isArray(user?.linkedProviders) ? user.linkedProviders : []
   const isKakaoLinked = linkedProviders.includes('kakao')
   const hasEmailPassword = linkedProviders.includes('email')
+  const isBusy = isSavingNickname || isChangingPassword || isLinkingKakao || isUnlinkingKakao || isDeleting
 
   const passwordValidationMessage = useMemo(() => {
     if (!hasEmailPassword) return ''
@@ -57,7 +58,7 @@ function AccountPanel({
     if (currentPassword.length < 8) return '현재 비밀번호를 입력해주세요.'
     if (newPassword.length < 8 || newPassword.length > 72) return '새 비밀번호는 8~72자로 입력해주세요.'
     if (!/[A-Za-z]/.test(newPassword) || !/\d/.test(newPassword)) {
-      return '새 비밀번호는 영문과 숫자를 모두 포함해야 합니다.'
+      return '새 비밀번호에는 영문과 숫자가 모두 포함되어야 합니다.'
     }
     if (!confirmPassword) return '새 비밀번호 확인을 입력해주세요.'
     if (newPassword !== confirmPassword) return '새 비밀번호와 확인 값이 일치하지 않습니다.'
@@ -143,7 +144,7 @@ function AccountPanel({
       setError('')
       setSuccess('')
       await onUnlinkKakao()
-      setSuccess('카카오 계정 연결이 해제되었습니다.')
+      setSuccess('카카오 계정 연결을 해제했습니다.')
     } catch (nextError) {
       setError(nextError.message || '카카오 계정 연결 해제에 실패했습니다.')
       setSuccess('')
@@ -193,6 +194,33 @@ function AccountPanel({
         </div>
       </div>
 
+      {(error || success) && (
+        <div className={`account-feedback-banner ${error ? 'is-error' : 'is-success'}`}>
+          {error ? <p className="error-text">{error}</p> : <p className="success-text">{success}</p>}
+        </div>
+      )}
+
+      <section className="account-section">
+        <div className="account-section-header">
+          <h4>로그인 방식</h4>
+          <p>지금 사용할 수 있는 로그인 수단과 연결 상태를 한눈에 확인할 수 있어요.</p>
+        </div>
+
+        <div className="account-status-grid">
+          <div className={`account-status-card ${hasEmailPassword ? 'is-active' : 'is-inactive'}`}>
+            <span className="account-status-label">이메일 로그인</span>
+            <strong>{hasEmailPassword ? '사용 가능' : '사용 불가'}</strong>
+            <p>{hasEmailPassword ? '이메일로 바로 로그인할 수 있어요.' : '이메일 로그인 수단이 아직 연결되지 않았어요.'}</p>
+          </div>
+
+          <div className={`account-status-card ${isKakaoLinked ? 'is-active' : 'is-inactive'}`}>
+            <span className="account-status-label">카카오 간편로그인</span>
+            <strong>{isKakaoLinked ? '연결됨' : '미연결'}</strong>
+            <p>{isKakaoLinked ? '다음부터 카카오로 더 빠르게 로그인할 수 있어요.' : '보조 로그인 수단으로 카카오를 연결할 수 있어요.'}</p>
+          </div>
+        </div>
+      </section>
+
       {emphasizeKakaoLink && !isKakaoLinked && (
         <div className="account-highlight-card">
           <strong>카카오 간편로그인을 연결할까요?</strong>
@@ -203,7 +231,7 @@ function AccountPanel({
       <section className="account-section">
         <div className="account-section-header">
           <h4>내 정보</h4>
-          <p>계정의 기본 정보는 수정 버튼을 눌렀을 때만 변경할 수 있어요.</p>
+          <p>계정 기본 정보는 수정 버튼을 눌렀을 때만 변경할 수 있어요.</p>
         </div>
 
         <label className="settings-field">
@@ -228,7 +256,7 @@ function AccountPanel({
               type="button"
               className="inline-action-button"
               onClick={() => void handleSaveNickname()}
-              disabled={isSavingNickname || isChangingPassword || isLinkingKakao || isUnlinkingKakao || isDeleting}
+              disabled={isBusy}
             >
               {isSavingNickname ? '저장 중...' : '확인'}
             </button>
@@ -236,7 +264,7 @@ function AccountPanel({
               type="button"
               className="secondary inline-action-button"
               onClick={handleCancelEdit}
-              disabled={isSavingNickname || isChangingPassword || isLinkingKakao || isUnlinkingKakao || isDeleting}
+              disabled={isBusy}
             >
               취소
             </button>
@@ -250,7 +278,7 @@ function AccountPanel({
               setSuccess('')
               setIsEditingProfile(true)
             }}
-            disabled={isChangingPassword || isLinkingKakao || isUnlinkingKakao || isDeleting}
+            disabled={isBusy}
           >
             내 정보 변경
           </button>
@@ -260,36 +288,38 @@ function AccountPanel({
       <section className="account-section">
         <div className="account-section-header">
           <h4>간편로그인</h4>
-          <p>이메일 계정에 카카오 계정을 연결하면 다음부터 더 쉽게 로그인할 수 있어요.</p>
+          <p>이메일 계정에 카카오 계정을 연결하면 다음부터 더 빠르게 로그인할 수 있어요.</p>
         </div>
 
-        <button
-          type="button"
-          className="secondary inline-action-button"
-          onClick={() => void handleStartKakaoLink()}
-          disabled={isSavingNickname || isChangingPassword || isLinkingKakao || isUnlinkingKakao || isDeleting || isKakaoLinked}
-        >
-          {isKakaoLinked ? '카카오 계정 연결됨' : isLinkingKakao ? '카카오 연결 중...' : '카카오 계정 연결'}
-        </button>
+        <div className="account-inline-actions account-inline-actions-stack">
+          <button
+            type="button"
+            className="secondary inline-action-button"
+            onClick={() => void handleStartKakaoLink()}
+            disabled={isBusy || isKakaoLinked}
+          >
+            {isKakaoLinked ? '카카오 계정 연결됨' : isLinkingKakao ? '카카오 연결 중...' : '카카오 계정 연결'}
+          </button>
 
-        <button
-          type="button"
-          className="secondary inline-action-button"
-          onClick={() => void handleUnlinkKakao()}
-          disabled={isSavingNickname || isChangingPassword || isLinkingKakao || isUnlinkingKakao || isDeleting || !isKakaoLinked || !hasEmailPassword}
-        >
-          {isUnlinkingKakao ? '연결 해제 중...' : '카카오 연결 해제'}
-        </button>
+          <button
+            type="button"
+            className="secondary inline-action-button"
+            onClick={() => void handleUnlinkKakao()}
+            disabled={isBusy || !isKakaoLinked || !hasEmailPassword}
+          >
+            {isUnlinkingKakao ? '연결 해제 중...' : '카카오 연결 해제'}
+          </button>
+        </div>
 
         {!hasEmailPassword && isKakaoLinked && (
-          <p className="muted-text">이메일 로그인 수단이 없으면 마지막 간편로그인은 해제할 수 없습니다.</p>
+          <p className="muted-text">이메일 로그인 수단이 없으면 마지막 간편로그인 연결은 해제할 수 없습니다.</p>
         )}
       </section>
 
       <section className="account-section">
         <div className="account-section-header">
           <h4>비밀번호 변경</h4>
-          <p>이메일 로그인 계정인 경우에만 현재 비밀번호 확인 후 변경할 수 있어요.</p>
+          <p>이메일 로그인 계정인 경우에만 현재 비밀번호를 확인한 뒤 변경할 수 있어요.</p>
         </div>
 
         {hasEmailPassword ? (
@@ -330,7 +360,7 @@ function AccountPanel({
               type="button"
               className="inline-action-button"
               onClick={() => void handleChangePassword()}
-              disabled={isSavingNickname || isChangingPassword || isLinkingKakao || isUnlinkingKakao || isDeleting}
+              disabled={isBusy}
             >
               {isChangingPassword ? '변경 중...' : '비밀번호 변경'}
             </button>
@@ -350,14 +380,11 @@ function AccountPanel({
           type="button"
           className="secondary inline-action-button danger-zone-button"
           onClick={() => void handleDeleteAccount()}
-          disabled={isSavingNickname || isChangingPassword || isLinkingKakao || isUnlinkingKakao || isDeleting}
+          disabled={isBusy}
         >
           {isDeleting ? '회원탈퇴 처리 중...' : '회원탈퇴'}
         </button>
       </section>
-
-      {error && <p className="error-text account-feedback">{error}</p>}
-      {success && <p className="success-text account-feedback">{success}</p>}
     </div>
   )
 }


### PR DESCRIPTION
﻿Title
fix: polish account management panel

Summary
내 정보 화면에서 저장/실패 피드백과 로그인 수단 상태를 더 읽기 쉽게 정리했다. 변경 범위는 `AccountPanel` 전용 파일 안으로만 한정해서, 다른 화면에 스타일 영향이 퍼지지 않도록 유지했다.

Changed Files
- C:\Users\yoooo\flownium-chat-2.0\src\features\user\components\AccountPanel.jsx
- C:\Users\yoooo\flownium-chat-2.0\src\features\user\components\AccountPanel.css
- C:\Users\yoooo\flownium-chat-2.0\.codex\worklogs\2026-03-12-account-management-finish.md

What’s Included
- 저장/실패 메시지를 상단 배너로 이동
- 이메일 로그인 / 카카오 간편로그인 상태 카드 추가
- 카카오 연결/해제 액션을 같은 그룹으로 정리
- `AccountPanel` 범위 내에서만 계정 관리 UI 문구와 상호작용 정리
- task worklog 추가

Impact
- 내 정보 화면 계정 상태 가독성
- 카카오 연결/해제 액션 배치
- 저장/실패 피드백 노출 위치
- 공용 CSS 영향 없음

Validation
- npm run build

Branch / Commit
- Branch: fix/account-management-finish
- Commit: cc8485d
- Push: origin/fix/account-management-finish

PR
- pending
