### PR TITLE
docs: clarify merged-pr reporting rules

### DIFF
--- a/.codex/worklogs/2026-03-12-docs-merge-state-reporting-rule.md
+++ b/.codex/worklogs/2026-03-12-docs-merge-state-reporting-rule.md
@@ -1,0 +1,13 @@
+## Task
+- Add collaboration rules to avoid re-reporting already merged PRs and to check local worktree state before blaming merged commits or deployment.
+
+## Changes
+- Updated `AGENTS.md` reporting rules so merged PRs are treated as closed in subsequent responses.
+- Updated `CONTRIBUTING.md` merge/incident rules to require checking local uncommitted changes before assuming deployment or merged PR issues.
+
+## Files
+- `AGENTS.md`
+- `CONTRIBUTING.md`
+
+## Validation
+- Re-read the updated rule sections after editing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,9 @@ Agents must review `docs/development-rules.md` before changing code, documentati
 3. If something failed or was not applied, state that first and clearly.
 4. When a task changes code, docs, validation status, or release readiness, update a task-specific worklog under `.codex/worklogs/` in the same task.
 5. When a PR is intended to resolve a tracked GitHub Issue, include a closing keyword such as `Closes #123` in the PR body.
+6. If the user explicitly says a PR was merged, treat that PR and branch as closed in all following responses unless the user reopens that topic.
+7. After a PR is treated as merged, do not describe it as pending, newly opened, or needing upload again.
+8. Before suggesting rollback or redeployment as the cause of a mismatch, first check whether the local worktree contains uncommitted changes.
 
 ## 5. Validation Baseline
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,3 +69,5 @@ Issue Closure
 1. Do not merge before the PR stage is complete.
 2. If an operational issue occurs, document root cause, mitigation, and prevention.
 3. If a documentation review reveals a code issue, track it separately instead of hiding it inside a docs-only change.
+4. If a collaborator says a PR was already merged, treat that PR as closed state from that point onward and move to the next task unless they explicitly ask to revisit it.
+5. When local and production differ, check `git status` and local uncommitted changes before assuming the merged PR or deployment is wrong.


### PR DESCRIPTION
﻿Title
docs: clarify merged-pr reporting rules

Summary
사용자가 이미 머지했다고 말한 PR을 다시 진행 중처럼 보고하는 혼선을 막기 위해 협업 규칙을 보강했다. 또한 로컬과 운영 차이가 날 때는 먼저 local worktree 오염 여부를 확인하도록 incident rule을 추가했다.

Changed Files
- C:\Users\yoooo\flownium-chat-2.0\AGENTS.md
- C:\Users\yoooo\flownium-chat-2.0\CONTRIBUTING.md
- C:\Users\yoooo\flownium-chat-2.0\.codex\worklogs\2026-03-12-docs-merge-state-reporting-rule.md

What’s Included
- 머지 완료된 PR을 후속 응답에서 종료 상태로 취급하는 규칙 추가
- 이미 머지된 PR을 다시 pending/upload 상태처럼 말하지 않도록 reporting rule 보강
- 로컬/운영 차이 분석 시 `git status`와 미커밋 변경을 먼저 확인하도록 incident rule 추가
- task worklog 추가

Impact
- PR 상태 보고 방식
- merge 이후 후속 커뮤니케이션
- 로컬/운영 차이 원인 파악 절차

Validation
- Updated rule sections re-read after edit

Branch / Commit
- Branch: feat/email-change-flow
- Commit: 217703e
- Push: origin/feat/email-change-flow

PR
- pending
